### PR TITLE
Feat/modulo de ciudades cu 86a9c4hub

### DIFF
--- a/prisma/data/ciudades.ts
+++ b/prisma/data/ciudades.ts
@@ -1,0 +1,528 @@
+import { Ciudad } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+
+export const ciudades = [
+  // PROVINCIA DE PICHINCHA
+  {
+    nombre: 'Quito',
+    provincia: 'Pichincha',
+    latitud: new Decimal(-0.180653),
+    longitud: new Decimal(-78.467834),
+    activo: true,
+  },
+  {
+    nombre: 'Cayambe',
+    provincia: 'Pichincha',
+    latitud: new Decimal(0.041016),
+    longitud: new Decimal(-78.146484),
+    activo: true,
+  },
+  {
+    nombre: 'Machachi',
+    provincia: 'Pichincha',
+    latitud: new Decimal(-0.510417),
+    longitud: new Decimal(-78.567708),
+    activo: true,
+  },
+  {
+    nombre: 'Tabacundo',
+    provincia: 'Pichincha',
+    latitud: new Decimal(0.041667),
+    longitud: new Decimal(-78.233333),
+    activo: true,
+  },
+
+  // PROVINCIA DE GUAYAS
+  {
+    nombre: 'Guayaquil',
+    provincia: 'Guayas',
+    latitud: new Decimal(-2.170998),
+    longitud: new Decimal(-79.922359),
+    activo: true,
+  },
+  {
+    nombre: 'Milagro',
+    provincia: 'Guayas',
+    latitud: new Decimal(-2.134167),
+    longitud: new Decimal(-79.594444),
+    activo: true,
+  },
+  {
+    nombre: 'Daule',
+    provincia: 'Guayas',
+    latitud: new Decimal(-1.863889),
+    longitud: new Decimal(-79.976944),
+    activo: true,
+  },
+  {
+    nombre: 'Durán',
+    provincia: 'Guayas',
+    latitud: new Decimal(-2.170417),
+    longitud: new Decimal(-79.839167),
+    activo: true,
+  },
+  {
+    nombre: 'Playas',
+    provincia: 'Guayas',
+    latitud: new Decimal(-2.628889),
+    longitud: new Decimal(-80.388333),
+    activo: true,
+  },
+
+  // PROVINCIA DE AZUAY
+  {
+    nombre: 'Cuenca',
+    provincia: 'Azuay',
+    latitud: new Decimal(-2.9),
+    longitud: new Decimal(-79.005),
+    activo: true,
+  },
+  {
+    nombre: 'Gualaceo',
+    provincia: 'Azuay',
+    latitud: new Decimal(-2.892778),
+    longitud: new Decimal(-78.779444),
+    activo: true,
+  },
+  {
+    nombre: 'Paute',
+    provincia: 'Azuay',
+    latitud: new Decimal(-2.776944),
+    longitud: new Decimal(-78.756944),
+    activo: true,
+  },
+
+  // PROVINCIA DE MANABÍ
+  {
+    nombre: 'Portoviejo',
+    provincia: 'Manabí',
+    latitud: new Decimal(-1.054167),
+    longitud: new Decimal(-80.455),
+    activo: true,
+  },
+  {
+    nombre: 'Manta',
+    provincia: 'Manabí',
+    latitud: new Decimal(-0.954722),
+    longitud: new Decimal(-80.732222),
+    activo: true,
+  },
+  {
+    nombre: 'Chone',
+    provincia: 'Manabí',
+    latitud: new Decimal(-0.691667),
+    longitud: new Decimal(-80.094167),
+    activo: true,
+  },
+  {
+    nombre: 'Bahía de Caráquez',
+    provincia: 'Manabí',
+    latitud: new Decimal(-0.6),
+    longitud: new Decimal(-80.424722),
+    activo: true,
+  },
+  {
+    nombre: 'Montecristi',
+    provincia: 'Manabí',
+    latitud: new Decimal(-1.044722),
+    longitud: new Decimal(-80.659722),
+    activo: true,
+  },
+
+  // PROVINCIA DE EL ORO
+  {
+    nombre: 'Machala',
+    provincia: 'El Oro',
+    latitud: new Decimal(-3.258333),
+    longitud: new Decimal(-79.955556),
+    activo: true,
+  },
+  {
+    nombre: 'Pasaje',
+    provincia: 'El Oro',
+    latitud: new Decimal(-3.326944),
+    longitud: new Decimal(-79.808333),
+    activo: true,
+  },
+  {
+    nombre: 'Huaquillas',
+    provincia: 'El Oro',
+    latitud: new Decimal(-3.478056),
+    longitud: new Decimal(-80.230556),
+    activo: true,
+  },
+  {
+    nombre: 'Santa Rosa',
+    provincia: 'El Oro',
+    latitud: new Decimal(-3.448889),
+    longitud: new Decimal(-79.959722),
+    activo: true,
+  },
+
+  // PROVINCIA DE TUNGURAHUA
+  {
+    nombre: 'Ambato',
+    provincia: 'Tungurahua',
+    latitud: new Decimal(-1.24),
+    longitud: new Decimal(-78.63),
+    activo: true,
+  },
+  {
+    nombre: 'Baños',
+    provincia: 'Tungurahua',
+    latitud: new Decimal(-1.396944),
+    longitud: new Decimal(-78.422222),
+    activo: true,
+  },
+  {
+    nombre: 'Pelileo',
+    provincia: 'Tungurahua',
+    latitud: new Decimal(-1.331667),
+    longitud: new Decimal(-78.545),
+    activo: true,
+  },
+
+  // PROVINCIA DE CHIMBORAZO
+  {
+    nombre: 'Riobamba',
+    provincia: 'Chimborazo',
+    latitud: new Decimal(-1.67),
+    longitud: new Decimal(-78.6475),
+    activo: true,
+  },
+  {
+    nombre: 'Alausí',
+    provincia: 'Chimborazo',
+    latitud: new Decimal(-2.200833),
+    longitud: new Decimal(-78.843056),
+    activo: true,
+  },
+  {
+    nombre: 'Guano',
+    provincia: 'Chimborazo',
+    latitud: new Decimal(-1.608333),
+    longitud: new Decimal(-78.63),
+    activo: true,
+  },
+
+  // PROVINCIA DE LOJA
+  {
+    nombre: 'Loja',
+    provincia: 'Loja',
+    latitud: new Decimal(-3.993056),
+    longitud: new Decimal(-79.205),
+    activo: true,
+  },
+  {
+    nombre: 'Catamayo',
+    provincia: 'Loja',
+    latitud: new Decimal(-3.986667),
+    longitud: new Decimal(-79.353889),
+    activo: true,
+  },
+  {
+    nombre: 'Cariamanga',
+    provincia: 'Loja',
+    latitud: new Decimal(-4.331944),
+    longitud: new Decimal(-79.545833),
+    activo: true,
+  },
+
+  // PROVINCIA DE IMBABURA
+  {
+    nombre: 'Ibarra',
+    provincia: 'Imbabura',
+    latitud: new Decimal(0.35),
+    longitud: new Decimal(-78.1225),
+    activo: true,
+  },
+  {
+    nombre: 'Otavalo',
+    provincia: 'Imbabura',
+    latitud: new Decimal(0.234167),
+    longitud: new Decimal(-78.261389),
+    activo: true,
+  },
+  {
+    nombre: 'Cotacachi',
+    provincia: 'Imbabura',
+    latitud: new Decimal(0.3),
+    longitud: new Decimal(-78.263889),
+    activo: true,
+  },
+
+  // PROVINCIA DE COTOPAXI
+  {
+    nombre: 'Latacunga',
+    provincia: 'Cotopaxi',
+    latitud: new Decimal(-0.9325),
+    longitud: new Decimal(-78.615),
+    activo: true,
+  },
+  {
+    nombre: 'La Maná',
+    provincia: 'Cotopaxi',
+    latitud: new Decimal(-0.940833),
+    longitud: new Decimal(-79.224444),
+    activo: true,
+  },
+  {
+    nombre: 'Saquisilí',
+    provincia: 'Cotopaxi',
+    latitud: new Decimal(-0.826944),
+    longitud: new Decimal(-78.665833),
+    activo: true,
+  },
+
+  // PROVINCIA DE LOS RÍOS
+  {
+    nombre: 'Babahoyo',
+    provincia: 'Los Ríos',
+    latitud: new Decimal(-1.8025),
+    longitud: new Decimal(-79.534167),
+    activo: true,
+  },
+  {
+    nombre: 'Quevedo',
+    provincia: 'Los Ríos',
+    latitud: new Decimal(-1.03),
+    longitud: new Decimal(-79.463056),
+    activo: true,
+  },
+  {
+    nombre: 'Ventanas',
+    provincia: 'Los Ríos',
+    latitud: new Decimal(-1.44),
+    longitud: new Decimal(-79.458333),
+    activo: true,
+  },
+  {
+    nombre: 'Mocache',
+    provincia: 'Los Ríos',
+    latitud: new Decimal(-1.183333),
+    longitud: new Decimal(-79.488056),
+    activo: true,
+  },
+
+  // PROVINCIA DE ESMERALDAS
+  {
+    nombre: 'Esmeraldas',
+    provincia: 'Esmeraldas',
+    latitud: new Decimal(0.966667),
+    longitud: new Decimal(-79.65),
+    activo: true,
+  },
+  {
+    nombre: 'Atacames',
+    provincia: 'Esmeraldas',
+    latitud: new Decimal(0.869444),
+    longitud: new Decimal(-79.846389),
+    activo: true,
+  },
+  {
+    nombre: 'Quinindé',
+    provincia: 'Esmeraldas',
+    latitud: new Decimal(0.325),
+    longitud: new Decimal(-79.468056),
+    activo: true,
+  },
+
+  // PROVINCIA DE CAÑAR
+  {
+    nombre: 'Azogues',
+    provincia: 'Cañar',
+    latitud: new Decimal(-2.738889),
+    longitud: new Decimal(-78.844722),
+    activo: true,
+  },
+  {
+    nombre: 'Cañar',
+    provincia: 'Cañar',
+    latitud: new Decimal(-2.56),
+    longitud: new Decimal(-78.940278),
+    activo: true,
+  },
+  {
+    nombre: 'La Troncal',
+    provincia: 'Cañar',
+    latitud: new Decimal(-2.423056),
+    longitud: new Decimal(-79.339167),
+    activo: true,
+  },
+
+  // PROVINCIA DE BOLÍVAR
+  {
+    nombre: 'Guaranda',
+    provincia: 'Bolívar',
+    latitud: new Decimal(-1.593056),
+    longitud: new Decimal(-79.0),
+    activo: true,
+  },
+  {
+    nombre: 'San Miguel',
+    provincia: 'Bolívar',
+    latitud: new Decimal(-1.710833),
+    longitud: new Decimal(-79.05),
+    activo: true,
+  },
+
+  // PROVINCIA DE CARCHI
+  {
+    nombre: 'Tulcán',
+    provincia: 'Carchi',
+    latitud: new Decimal(0.812222),
+    longitud: new Decimal(-77.717778),
+    activo: true,
+  },
+  {
+    nombre: 'San Gabriel',
+    provincia: 'Carchi',
+    latitud: new Decimal(0.588889),
+    longitud: new Decimal(-77.831667),
+    activo: true,
+  },
+
+  // PROVINCIA DE SUCUMBÍOS
+  {
+    nombre: 'Nueva Loja (Lago Agrio)',
+    provincia: 'Sucumbíos',
+    latitud: new Decimal(0.093056),
+    longitud: new Decimal(-76.195),
+    activo: true,
+  },
+  {
+    nombre: 'Shushufindi',
+    provincia: 'Sucumbíos',
+    latitud: new Decimal(0.175833),
+    longitud: new Decimal(-76.641389),
+    activo: true,
+  },
+
+  // PROVINCIA DE ORELLANA
+  {
+    nombre: 'Puerto Francisco de Orellana (El Coca)',
+    provincia: 'Orellana',
+    latitud: new Decimal(-0.462778),
+    longitud: new Decimal(-76.987222),
+    activo: true,
+  },
+  {
+    nombre: 'Loreto',
+    provincia: 'Orellana',
+    latitud: new Decimal(-0.704444),
+    longitud: new Decimal(-77.283056),
+    activo: true,
+  },
+
+  // PROVINCIA DE NAPO
+  {
+    nombre: 'Tena',
+    provincia: 'Napo',
+    latitud: new Decimal(-0.993056),
+    longitud: new Decimal(-77.813056),
+    activo: true,
+  },
+  {
+    nombre: 'Archidona',
+    provincia: 'Napo',
+    latitud: new Decimal(-0.908333),
+    longitud: new Decimal(-77.808333),
+    activo: true,
+  },
+
+  // PROVINCIA DE PASTAZA
+  {
+    nombre: 'Puyo',
+    provincia: 'Pastaza',
+    latitud: new Decimal(-1.483333),
+    longitud: new Decimal(-78.0),
+    activo: true,
+  },
+  {
+    nombre: 'Shell',
+    provincia: 'Pastaza',
+    latitud: new Decimal(-1.493333),
+    longitud: new Decimal(-78.063889),
+    activo: true,
+  },
+
+  // PROVINCIA DE MORONA SANTIAGO
+  {
+    nombre: 'Macas',
+    provincia: 'Morona Santiago',
+    latitud: new Decimal(-2.31),
+    longitud: new Decimal(-78.121389),
+    activo: true,
+  },
+  {
+    nombre: 'Sucúa',
+    provincia: 'Morona Santiago',
+    latitud: new Decimal(-2.459722),
+    longitud: new Decimal(-78.163889),
+    activo: true,
+  },
+
+  // PROVINCIA DE ZAMORA CHINCHIPE
+  {
+    nombre: 'Zamora',
+    provincia: 'Zamora Chinchipe',
+    latitud: new Decimal(-4.066667),
+    longitud: new Decimal(-78.95),
+    activo: true,
+  },
+  {
+    nombre: 'Yantzaza',
+    provincia: 'Zamora Chinchipe',
+    latitud: new Decimal(-3.825),
+    longitud: new Decimal(-78.758333),
+    activo: true,
+  },
+
+  // PROVINCIA DE GALÁPAGOS
+  {
+    nombre: 'Puerto Baquerizo Moreno',
+    provincia: 'Galápagos',
+    latitud: new Decimal(-0.9),
+    longitud: new Decimal(-89.6),
+    activo: true,
+  },
+  {
+    nombre: 'Puerto Ayora',
+    provincia: 'Galápagos',
+    latitud: new Decimal(-0.742222),
+    longitud: new Decimal(-90.312222),
+    activo: true,
+  },
+
+  // PROVINCIA DE SANTO DOMINGO DE LOS TSÁCHILAS
+  {
+    nombre: 'Santo Domingo',
+    provincia: 'Santo Domingo de los Tsáchilas',
+    latitud: new Decimal(-0.2525),
+    longitud: new Decimal(-79.175),
+    activo: true,
+  },
+
+  // PROVINCIA DE SANTA ELENA
+  {
+    nombre: 'Santa Elena',
+    provincia: 'Santa Elena',
+    latitud: new Decimal(-2.226944),
+    longitud: new Decimal(-80.858333),
+    activo: true,
+  },
+  {
+    nombre: 'La Libertad',
+    provincia: 'Santa Elena',
+    latitud: new Decimal(-2.233333),
+    longitud: new Decimal(-80.910556),
+    activo: true,
+  },
+  {
+    nombre: 'Salinas',
+    provincia: 'Santa Elena',
+    latitud: new Decimal(-2.214167),
+    longitud: new Decimal(-80.955833),
+    activo: true,
+  },
+];

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, TipoUsuario } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
+import { ciudades } from './data/ciudades';
 const prisma = new PrismaClient();
 
 async function main() {
@@ -17,7 +18,11 @@ async function main() {
     },
   });
 
-  console.log(user);
+  await prisma.ciudad.deleteMany();
+
+  await prisma.ciudad.createMany({
+    data: ciudades,
+  });
 }
 
 main()

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { UbicacionAsientoPlantillasModule } from './modules/ubicacion-asiento-pl
 import { PlantillaPisosModule } from './modules/plantilla-pisos/plantilla-pisos.module';
 import { AsientosModule } from './modules/asientos/asientos.module';
 import { PisosBusModule } from './modules/pisos-bus/pisos-bus.module';
+import { CiudadesModule } from './modules/ciudades/ciudades.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { PisosBusModule } from './modules/pisos-bus/pisos-bus.module';
     AsientosModule,
     PlantillaPisosModule,
     UbicacionAsientoPlantillasModule,
+    CiudadesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/ciudades/ciudades.controller.ts
+++ b/src/modules/ciudades/ciudades.controller.ts
@@ -1,0 +1,80 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Query,
+  ParseIntPipe,
+  HttpStatus,
+  HttpCode,
+  ForbiddenException,
+} from '@nestjs/common';
+import { CiudadesService } from './ciudades.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { TipoUsuario, RolUsuario } from '@prisma/client';
+import { ApiBearerAuth, ApiTags, ApiOperation } from '@nestjs/swagger';
+import { filtroCiudadBuild } from './utils/filtro-ciudad-build';
+import { FiltroCiudadDto, CreateCiudadDto, UpdateCiudadDto } from './dto';
+
+@ApiTags('ciudades')
+@ApiBearerAuth()
+@Controller('ciudades')
+export class CiudadesController {
+  constructor(private readonly ciudadesService: CiudadesService) {}
+
+  @ApiOperation({ summary: 'Obtener todas las ciudades' })
+  @Get()
+  async obtenerCiudades(@Query() filtro: FiltroCiudadDto) {
+    const ciudades = await this.ciudadesService.obtenerCiudades(
+      filtroCiudadBuild(filtro),
+    );
+    return ciudades;
+  }
+
+  @ApiOperation({ summary: 'Obtener ciudad por ID' })
+  @Get(':id')
+  async obtenerCiudadPorId(@Param('id', ParseIntPipe) id: number) {
+    const ciudad = await this.ciudadesService.obtenerCiudad({ id });
+    return ciudad;
+  }
+
+  @ApiOperation({ summary: 'Crear nueva ciudad' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA)
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async crearCiudad(@Body() createCiudadDto: CreateCiudadDto) {
+    const ciudad = await this.ciudadesService.crearCiudad(createCiudadDto);
+    return ciudad;
+  }
+
+  @ApiOperation({ summary: 'Actualizar ciudad' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA)
+  @Put(':id')
+  async actualizarCiudad(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateCiudadDto: UpdateCiudadDto,
+  ) {
+    const ciudad = await this.ciudadesService.actualizarCiudad(
+      id,
+      updateCiudadDto,
+    );
+    return ciudad;
+  }
+
+  @ApiOperation({ summary: 'Desactivar ciudad' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA)
+  @Delete(':id')
+  async desactivarCiudad(@Param('id', ParseIntPipe) id: number) {
+    const ciudad = await this.ciudadesService.desactivarCiudad(id);
+    return ciudad;
+  }
+}

--- a/src/modules/ciudades/ciudades.module.ts
+++ b/src/modules/ciudades/ciudades.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { CiudadesController } from './ciudades.controller';
+import { CiudadesService } from './ciudades.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [CiudadesController],
+  providers: [CiudadesService],
+  exports: [CiudadesService],
+})
+export class CiudadesModule {}

--- a/src/modules/ciudades/ciudades.service.ts
+++ b/src/modules/ciudades/ciudades.service.ts
@@ -1,0 +1,107 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+import { CIUDAD_SELECT } from './constants/ciudad-select';
+import { CreateCiudadDto, UpdateCiudadDto } from './dto';
+
+@Injectable()
+export class CiudadesService {
+  constructor(private prisma: PrismaService) {}
+
+  async obtenerCiudades(
+    filtro: Prisma.CiudadWhereInput,
+    args: Prisma.CiudadSelect = CIUDAD_SELECT,
+  ) {
+    return await this.prisma.ciudad.findMany({
+      where: filtro,
+      orderBy: { nombre: 'asc' },
+      select: args,
+    });
+  }
+
+  async obtenerCiudad(
+    filtro: Prisma.CiudadWhereUniqueInput,
+    args: Prisma.CiudadSelect = CIUDAD_SELECT,
+  ) {
+    const ciudad = await this.prisma.ciudad.findUnique({
+      where: filtro,
+      select: args,
+    });
+
+    if (!ciudad) {
+      throw new NotFoundException(
+        `Ciudad con el filtro ${JSON.stringify(filtro)} no encontrada`,
+      );
+    }
+
+    return ciudad;
+  }
+
+  async crearCiudad(datos: CreateCiudadDto, tx?: Prisma.TransactionClient) {
+    // Verificar si ya existe una ciudad con el mismo nombre y provincia
+    const existente = await this.prisma.ciudad.findFirst({
+      where: {
+        nombre: datos.nombre,
+        provincia: datos.provincia,
+      },
+    });
+
+    if (existente) {
+      throw new ConflictException(
+        `Ya existe una ciudad con el nombre ${datos.nombre} en la provincia ${datos.provincia}`,
+      );
+    }
+
+    return await (tx || this.prisma).ciudad.create({
+      data: {
+        ...datos,
+        activo: true,
+      },
+      select: CIUDAD_SELECT,
+    });
+  }
+
+  async actualizarCiudad(
+    id: number,
+    datos: UpdateCiudadDto,
+    tx?: Prisma.TransactionClient,
+  ) {
+    await this.obtenerCiudad({ id });
+
+    if (datos.nombre && datos.provincia) {
+      const existente = await this.prisma.ciudad.findFirst({
+        where: {
+          nombre: datos.nombre,
+          provincia: datos.provincia,
+          NOT: [{ id: id }],
+        },
+      });
+
+      if (existente) {
+        throw new ConflictException(
+          `Ya existe una ciudad con el nombre ${datos.nombre} en la provincia ${datos.provincia}`,
+        );
+      }
+    }
+
+    return await (tx || this.prisma).ciudad.update({
+      where: { id },
+      data: datos,
+      select: CIUDAD_SELECT,
+    });
+  }
+
+  async desactivarCiudad(id: number, tx?: Prisma.TransactionClient) {
+    await this.obtenerCiudad({ id });
+
+    return await (tx || this.prisma).ciudad.update({
+      where: { id },
+      data: { activo: false },
+      select: CIUDAD_SELECT,
+    });
+  }
+}

--- a/src/modules/ciudades/constants/ciudad-select.ts
+++ b/src/modules/ciudades/constants/ciudad-select.ts
@@ -1,0 +1,16 @@
+import { Prisma } from '@prisma/client';
+
+export const CIUDAD_SELECT: Prisma.CiudadSelect = {
+  id: true,
+  nombre: true,
+  provincia: true,
+  latitud: true,
+  longitud: true,
+  activo: true,
+};
+
+export const CIUDAD_SELECT_WITH_RELATIONS: Prisma.CiudadSelect = {
+  ...CIUDAD_SELECT,
+  segmentosOrigen: true,
+  segmentosDestino: true,
+};

--- a/src/modules/ciudades/dto/create-ciudad.dto.ts
+++ b/src/modules/ciudades/dto/create-ciudad.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsDecimal,
+  Max,
+  Min,
+  IsNumber,
+} from 'class-validator';
+
+export class CreateCiudadDto {
+  @ApiProperty({
+    description: 'Nombre de la ciudad',
+    example: 'Quito',
+  })
+  @IsString({ message: 'El nombre debe ser una cadena de caracteres' })
+  @IsNotEmpty({ message: 'El nombre es requerido' })
+  nombre: string;
+
+  @ApiProperty({
+    description: 'Provincia donde se encuentra la ciudad',
+    example: 'Pichincha',
+  })
+  @IsString({ message: 'La provincia debe ser una cadena de caracteres' })
+  @IsNotEmpty({ message: 'La provincia es requerida' })
+  provincia: string;
+
+  @ApiPropertyOptional({
+    description: 'Latitud geográfica de la ciudad (grados decimales)',
+    example: -0.225219,
+  })
+  @IsOptional()
+  @IsNumber({}, { message: 'La latitud debe ser un número' })
+  @Min(-90, { message: 'La latitud mínima es -90' })
+  @Max(90, { message: 'La latitud máxima es 90' })
+  latitud?: number;
+
+  @ApiPropertyOptional({
+    description: 'Longitud geográfica de la ciudad (grados decimales)',
+    example: -78.5248,
+  })
+  @IsOptional()
+  @IsNumber({}, { message: 'La longitud debe ser un número' })
+  @Min(-180, { message: 'La longitud mínima es -180' })
+  @Max(180, { message: 'La longitud máxima es 180' })
+  longitud?: number;
+}

--- a/src/modules/ciudades/dto/filtro-ciudad.dto.ts
+++ b/src/modules/ciudades/dto/filtro-ciudad.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class FiltroCiudadDto {
+  @ApiProperty({
+    description: 'Filtrar por estado activo',
+    required: false,
+  })
+  @IsBoolean({ message: 'El activo debe ser un booleano' })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return undefined;
+  })
+  activo?: boolean = true;
+
+  @ApiProperty({
+    description: 'Filtrar por nombre de ciudad',
+    required: false,
+  })
+  @IsString({ message: 'El nombre debe ser una cadena de caracteres' })
+  @IsOptional()
+  nombre?: string;
+
+  @ApiProperty({
+    description: 'Filtrar por provincia',
+    required: false,
+  })
+  @IsString({ message: 'La provincia debe ser una cadena de caracteres' })
+  @IsOptional()
+  provincia?: string;
+}

--- a/src/modules/ciudades/dto/index.ts
+++ b/src/modules/ciudades/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './create-ciudad.dto';
+export * from './update-ciudad.dto';
+export * from './filtro-ciudad.dto';

--- a/src/modules/ciudades/dto/update-ciudad.dto.ts
+++ b/src/modules/ciudades/dto/update-ciudad.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsBoolean } from 'class-validator';
+import { PartialType } from '@nestjs/swagger';
+import { CreateCiudadDto } from './create-ciudad.dto';
+
+export class UpdateCiudadDto extends PartialType(CreateCiudadDto) {
+  @ApiPropertyOptional({
+    description: 'Estado activo de la ciudad',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean({
+    message: 'El estado activo debe ser un booleano',
+  })
+  activo?: boolean;
+}

--- a/src/modules/ciudades/utils/filtro-ciudad-build.ts
+++ b/src/modules/ciudades/utils/filtro-ciudad-build.ts
@@ -1,0 +1,24 @@
+import { Prisma } from '@prisma/client';
+import { FiltroCiudadDto } from '../dto/filtro-ciudad.dto';
+
+export const filtroCiudadBuild = (
+  filtro: FiltroCiudadDto,
+): Prisma.CiudadWhereInput => {
+  const where: Prisma.CiudadWhereInput = {};
+
+  const { nombre, provincia, activo } = filtro;
+
+  if (nombre) {
+    where.nombre = { contains: nombre, mode: 'insensitive' };
+  }
+
+  if (provincia) {
+    where.provincia = { contains: provincia, mode: 'insensitive' };
+  }
+
+  if (activo !== undefined) {
+    where.activo = activo;
+  }
+
+  return where;
+};


### PR DESCRIPTION
This pull request introduces a new feature to manage cities (`ciudades`) in the application, including CRUD operations, filtering capabilities, and integration with the Prisma ORM. Additionally, the `seed` script has been updated to populate city data, and the `AppModule` has been modified to include the new `CiudadesModule`.

### Feature: Cities Management (`ciudades`)

**Controllers and Services:**
- Added `CiudadesController` with endpoints for creating, updating, deleting, and retrieving cities, including filtering options. It integrates guards and roles for access control.
- Implemented `CiudadesService` to handle business logic for city operations, including validations to prevent duplicates and exceptions for missing records.

**DTOs and Utilities:**
- Created `CreateCiudadDto`, `UpdateCiudadDto`, and `FiltroCiudadDto` to define the structure of data for city operations and filtering. These include validation rules and Swagger documentation. [[1]](diffhunk://#diff-2f2e6dbde5e14b8f7cea2d419747cb92bbcf8f53e79e490036289e0592319aa3R1-R49) [[2]](diffhunk://#diff-f307601324e2f56d6c12fa335bf53fffc9a96037621566398131846db2eade10R1-R16) [[3]](diffhunk://#diff-f55a87eaefff63ecdde2830655821e3d2f1247c9c8a1c5e511e837ffc25aeeedR1-R34)
- Added `filtroCiudadBuild` utility to construct Prisma filters for city queries based on DTO input.

**Constants:**
- Defined `CIUDAD_SELECT` and `CIUDAD_SELECT_WITH_RELATIONS` to specify fields for city queries, optimizing data retrieval.

### Integration with Application

**Module Updates:**
- Created `CiudadesModule` to encapsulate the cities feature, importing necessary dependencies like `PrismaModule`.
- Updated `AppModule` to include `CiudadesModule` in the application imports. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R19) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R40)

### Seed Script Enhancements

**Database Seeding:**
- Updated `prisma/seed.ts` to delete existing city records and populate the database with predefined city data from `ciudades`. [[1]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR3) [[2]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bL20-R25)