### PR TITLE
Feat/modulo viajes cu 86a9fh4u7

### DIFF
--- a/prisma/data/ciudades.ts
+++ b/prisma/data/ciudades.ts
@@ -1,7 +1,7 @@
-import { Ciudad } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 
-export const ciudades = [
+export const ciudades: Prisma.CiudadCreateInput[] = [
   // PROVINCIA DE PICHINCHA
   {
     nombre: 'Quito',

--- a/prisma/migrations/20250615001428_delete_rutas_of_viajes/migration.sql
+++ b/prisma/migrations/20250615001428_delete_rutas_of_viajes/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `rutaId` on the `viajes` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[horarioRutaId,fecha,busId]` on the table `viajes` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "viajes" DROP CONSTRAINT "viajes_rutaId_fkey";
+
+-- DropIndex
+DROP INDEX "viajes_fecha_rutaId_estado_idx";
+
+-- DropIndex
+DROP INDEX "viajes_rutaId_fecha_horarioRutaId_busId_key";
+
+-- AlterTable
+ALTER TABLE "viajes" DROP COLUMN "rutaId";
+
+-- CreateIndex
+CREATE INDEX "viajes_fecha_horarioRutaId_estado_idx" ON "viajes"("fecha", "horarioRutaId", "estado");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "viajes_horarioRutaId_fecha_busId_key" ON "viajes"("horarioRutaId", "fecha", "busId");

--- a/prisma/migrations/20250615032809_change_hora_salida_real/migration.sql
+++ b/prisma/migrations/20250615032809_change_hora_salida_real/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "viajes" ALTER COLUMN "horaSalidaReal" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -323,7 +323,6 @@ model Ruta {
   resolucion    ResolucionANT @relation(fields: [resolucionId], references: [id])
   paradas       ParadaRuta[] // Paradas intermedias ordenadas
   horarios      HorarioRuta[] // Horarios de salida de la ruta
-  viajes        Viaje[] // Instancias específicas de la ruta
 
   @@unique([tenantId, nombre])
   @@index([tenantId]) // Índice para búsquedas eficientes
@@ -377,13 +376,12 @@ model HorarioRuta {
 model Viaje {
   id               Int            @id @default(autoincrement())
   tenantId         Int
-  rutaId           Int
   horarioRutaId    Int
   busId            Int
   conductorId      Int?
   ayudanteId       Int?
   fecha            DateTime       @db.Date
-  horaSalidaReal   DateTime // Hora específica del viaje
+  horaSalidaReal   DateTime? // Hora específica del viaje
   estado           EstadoViaje    @default(PROGRAMADO)
   observaciones    String?
   capacidadTotal   Int // Cache del total de asientos
@@ -392,7 +390,6 @@ model Viaje {
 
   // Relaciones
   tenant      Tenant         @relation(fields: [tenantId], references: [id])
-  ruta        Ruta           @relation(fields: [rutaId], references: [id])
   horarioRuta HorarioRuta    @relation(fields: [horarioRutaId], references: [id])
   bus         Bus            @relation(fields: [busId], references: [id])
   conductor   UsuarioTenant? @relation("ViajesConductor", fields: [conductorId], references: [id])
@@ -402,9 +399,9 @@ model Viaje {
   ventas      Venta[]
   ocupaciones OcupacionAsiento[] // Gestión eficiente de ocupación por segmentos
 
-  @@unique([rutaId, fecha, horarioRutaId, busId])
+  @@unique([horarioRutaId, fecha, busId])
   @@index([tenantId, fecha, estado])
-  @@index([fecha, rutaId, estado]) // Para búsquedas de disponibilidad
+  @@index([fecha, horarioRutaId, estado]) // Para búsquedas de disponibilidad
   @@map("viajes")
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,28 +1,66 @@
-import { PrismaClient, TipoUsuario } from '@prisma/client';
-import * as bcrypt from 'bcrypt';
-import { ciudades } from './data/ciudades';
+// prisma/seeds/index.ts - Archivo principal
+import { PrismaClient } from '@prisma/client';
+import { seedModelosBuses } from './seeds/seed-modelo-buses-tipos-de-asientos';
+import { seedTenants } from './seeds/seed-tenants';
+import { seedUsuarios } from './seeds/seed-usuarios-personal';
+import { seedBuses } from './seeds/seed-buses';
+import { seedCiudades } from './seeds/seed-cuidades';
+import { seedRutas } from './seeds/seed-ruta-horario';
+
 const prisma = new PrismaClient();
 
 async function main() {
-  const user = await prisma.usuario.upsert({
-    where: {
-      username: 'admin',
-    },
-    update: {
-      passwordHash: bcrypt.hashSync('admin', 10),
-    },
-    create: {
-      username: 'admin',
-      passwordHash: bcrypt.hashSync('admin', 10),
-      tipoUsuario: TipoUsuario.ADMIN_SISTEMA,
-    },
-  });
+  console.log('🧹 Limpiando base de datos...');
+  await cleanDatabase();
 
+  console.log('📍 Creando ciudades...');
+  await seedCiudades(prisma);
+
+  console.log('👨‍💼 Creando usuarios y tenants...');
+  const { adminSistema, tenants } = await seedTenants(prisma);
+  const { usuariosPersonal, usuariosTenant } = await seedUsuarios(prisma, tenants);
+
+  console.log('🚌 Creando modelos de buses...');
+  const { modelosBus, plantillasPiso, tiposAsiento } = await seedModelosBuses(prisma, tenants);
+
+  console.log('🚐 Creando buses...');
+  await seedBuses(prisma, tenants, modelosBus, plantillasPiso, tiposAsiento);
+
+  console.log('🛣️ Creando rutas...');
+  const rutas = await seedRutas(prisma, tenants);
+
+  console.log('✅ Seed completado exitosamente!');
+}
+
+async function cleanDatabase() {
+  // Eliminar en orden inverso a las dependencias
+  await prisma.ocupacionAsiento.deleteMany();
+  await prisma.registroAbordaje.deleteMany();
+  await prisma.boleto.deleteMany();
+  await prisma.venta.deleteMany();
+  await prisma.viaje.deleteMany();
+  await prisma.horarioRuta.deleteMany();
+  await prisma.paradaRuta.deleteMany();
+  await prisma.ruta.deleteMany();
+  await prisma.asiento.deleteMany();
+  await prisma.pisoBus.deleteMany();
+  await prisma.caracteristicaBus.deleteMany();
+  await prisma.bus.deleteMany();
+  await prisma.tipoAsiento.deleteMany();
+  await prisma.ubicacionAsientoPlantilla.deleteMany();
+  await prisma.plantillaPiso.deleteMany();
+  await prisma.modeloBus.deleteMany();
+  await prisma.resolucionANT.deleteMany();
+  await prisma.personalCooperativa.deleteMany();
+  await prisma.usuarioTenant.deleteMany();
+  await prisma.cliente.deleteMany();
+  await prisma.configuracion.deleteMany();
+  await prisma.configuracionDescuento.deleteMany();
+  await prisma.metodoPago.deleteMany();
+  await prisma.notificacion.deleteMany();
+  await prisma.tenant.deleteMany();
   await prisma.ciudad.deleteMany();
-
-  await prisma.ciudad.createMany({
-    data: ciudades,
-  });
+  await prisma.usuario.deleteMany();
 }
 
 main()
@@ -30,7 +68,7 @@ main()
     await prisma.$disconnect();
   })
   .catch(async (e) => {
-    console.error(e);
+    console.error('❌ Error en seed:', e);
     await prisma.$disconnect();
     process.exit(1);
   });

--- a/prisma/seeds/seed-buses.ts
+++ b/prisma/seeds/seed-buses.ts
@@ -1,0 +1,196 @@
+// prisma/seeds/buses.seed.ts
+import { PrismaClient, EstadoBus, EstadoAsiento } from '@prisma/client';
+
+export async function seedBuses(prisma: PrismaClient, tenants: any[], modelosBus: any[], plantillasPiso: any[], tiposAsiento: any[]) {
+  const buses = [];
+  const pisosBus = [];
+
+  for (let tenantIndex = 0; tenantIndex < tenants.length; tenantIndex++) {
+    const tenant = tenants[tenantIndex];
+    const tenantPrefix = tenantIndex === 0 ? 'TPE' : tenantIndex === 1 ? 'TBA' : 'TRB';
+    
+    // Obtener tipos de asiento para este tenant
+    const tiposAsientoTenant = tiposAsiento.filter(ta => ta.tenantId === tenant.id);
+    
+    for (let busIndex = 1; busIndex <= 12; busIndex++) {
+      // Alternar entre diferentes modelos
+      const modeloIndex = (busIndex - 1) % modelosBus.length;
+      const modelo = modelosBus[modeloIndex];
+      
+      // Calcular asientos según el modelo
+      let totalAsientos;
+      switch (modeloIndex) {
+        case 0: totalAsientos = 44; break; // Mercedes-Benz
+        case 1: totalAsientos = 36; break; // Chevrolet
+        case 2: totalAsientos = 68; break; // Volvo (2 pisos)
+        case 3: totalAsientos = 30; break; // Isuzu
+        case 4: totalAsientos = 40; break; // Scania
+        case 5: totalAsientos = 42; break; // Hyundai
+        default: totalAsientos = 40;
+      }
+
+      const bus = await prisma.bus.create({
+        data: {
+          tenantId: tenant.id,
+          modeloBusId: modelo.id,
+          numero: (tenantIndex * 100) + 100 + busIndex,
+          placa: `${tenantPrefix}-${String(1000 + busIndex).slice(1)}`,
+          anioFabricacion: 2018 + (busIndex % 5),
+          totalAsientos,
+          fotoUrl: `https://example.com/bus-${tenantIndex}-${busIndex}.jpg`,
+          tipoCombustible: busIndex % 3 === 0 ? 'GNV' : 'Diésel',
+          fechaIngreso: new Date(2020 + (busIndex % 4), (busIndex % 12) + 1, 1),
+          estado: busIndex === 12 ? EstadoBus.MANTENIMIENTO : EstadoBus.ACTIVO,
+        },
+      });
+      buses.push(bus);
+
+      // Crear pisos para el bus según su modelo
+      const plantillasModelo = plantillasPiso.filter(p => p.modeloBusId === modelo.id);
+      
+      for (const plantilla of plantillasModelo) {
+        const pisoBus = await prisma.pisoBus.create({
+          data: {
+            busId: bus.id,
+            numeroPiso: plantilla.numeroPiso,
+            plantillaPisoId: plantilla.id,
+          },
+        });
+        pisosBus.push(pisoBus);
+
+        // Crear asientos para este piso
+        const asientos = [];
+        let numeroAsiento = plantilla.numeroPiso === 1 ? 1 : 
+                           plantilla.numeroPiso === 2 && modeloIndex === 2 ? 33 : 1; // Volvo 2do piso empieza en 33
+
+        for (let fila = 1; fila <= plantilla.filas; fila++) {
+          if (plantilla.columnas === 3) {
+            // Configuración 2+1 (Chevrolet NPR, Isuzu FRR)
+            for (let columna = 1; columna <= 3; columna++) {
+              // Alternar tipos de asiento por fila
+              const tipoAsiento = fila % 2 === 1 ? tiposAsientoTenant[0] : tiposAsientoTenant[1];
+              
+              asientos.push({
+                pisoBusId: pisoBus.id,
+                numero: `${numeroAsiento.toString().padStart(2, '0')}`,
+                fila,
+                columna,
+                tipoId: tipoAsiento?.id || tiposAsientoTenant[0]?.id,
+                estado: EstadoAsiento.DISPONIBLE,
+              });
+              
+              numeroAsiento++;
+            }
+          } else {
+            // Configuración 2+2 (Mercedes-Benz, Volvo, Scania, Hyundai)
+            for (let columna = 1; columna <= 4; columna++) {
+              // Alternar tipos de asiento por fila
+              const tipoAsiento = fila % 2 === 1 ? tiposAsientoTenant[0] : tiposAsientoTenant[1];
+              
+              asientos.push({
+                pisoBusId: pisoBus.id,
+                numero: `${numeroAsiento.toString().padStart(2, '0')}`,
+                fila,
+                columna,
+                tipoId: tipoAsiento?.id || tiposAsientoTenant[0]?.id,
+                estado: EstadoAsiento.DISPONIBLE,
+              });
+              
+              numeroAsiento++;
+            }
+          }
+        }
+
+        // Para el modelo Hyundai (índice 5), agregar 2 asientos extra al final
+        if (modeloIndex === 5) {
+          asientos.push(
+            {
+              pisoBusId: pisoBus.id,
+              numero: `${numeroAsiento.toString().padStart(2, '0')}`,
+              fila: plantilla.filas + 1,
+              columna: 2,
+              tipoId: tiposAsientoTenant[1]?.id || tiposAsientoTenant[0]?.id,
+              estado: EstadoAsiento.DISPONIBLE,
+            },
+            {
+              pisoBusId: pisoBus.id,
+              numero: `${(numeroAsiento + 1).toString().padStart(2, '0')}`,
+              fila: plantilla.filas + 1,
+              columna: 3,
+              tipoId: tiposAsientoTenant[1]?.id || tiposAsientoTenant[0]?.id,
+              estado: EstadoAsiento.DISPONIBLE,
+            }
+          );
+        }
+
+        await prisma.asiento.createMany({
+          data: asientos,
+        });
+      }
+
+      // Agregar características aleatorias al bus
+      const caracteristicas = [
+        { 
+          nombre: 'Aire Acondicionado', 
+          valor: busIndex % 2 === 0 ? 'Sí' : 'No' 
+        },
+        { 
+          nombre: 'WiFi', 
+          valor: busIndex > 6 ? 'Sí' : 'No' 
+        },
+        { 
+          nombre: 'TV', 
+          valor: busIndex % 3 === 0 ? 'Sí' : 'No' 
+        },
+        { 
+          nombre: 'Baño', 
+          valor: totalAsientos > 40 ? 'Sí' : 'No' 
+        },
+        { 
+          nombre: 'USB por asiento', 
+          valor: busIndex > 8 ? 'Sí' : 'No' 
+        },
+        { 
+          nombre: 'Sistema de audio', 
+          valor: 'Sí' 
+        },
+      ];
+
+      // Agregar características especiales según el modelo
+      if (modeloIndex === 2) { // Volvo (2 pisos)
+        caracteristicas.push({ nombre: 'Dos pisos', valor: 'Sí' });
+        caracteristicas.push({ nombre: 'Vista panorámica', valor: 'Sí' });
+      }
+      
+      if (modeloIndex === 4) { // Scania (ejecutivo)
+        caracteristicas.push({ nombre: 'Asientos reclinables', valor: 'Sí' });
+        caracteristicas.push({ nombre: 'Servicio a bordo', valor: 'Sí' });
+      }
+      
+      if (modeloIndex === 3) { // Isuzu (turístico)
+        caracteristicas.push({ nombre: 'Ventanas amplias', valor: 'Sí' });
+        caracteristicas.push({ nombre: 'Portaequipajes extra', valor: 'Sí' });
+      }
+
+      for (const caracteristica of caracteristicas) {
+        await prisma.caracteristicaBus.create({
+          data: {
+            busId: bus.id,
+            nombre: caracteristica.nombre,
+            valor: caracteristica.valor,
+          },
+        });
+      }
+    }
+  }
+
+  console.log(`✅ Creados ${buses.length} buses con ${pisosBus.length} pisos y todos sus asientos`);
+  console.log(`📊 Distribución por tenant:`);
+  
+  for (let i = 0; i < tenants.length; i++) {
+    const busesTenant = buses.filter(b => b.tenantId === tenants[i].id);
+    console.log(`   - ${tenants[i].nombre}: ${busesTenant.length} buses`);
+  }
+  
+  return { buses, pisosBus };
+}

--- a/prisma/seeds/seed-cuidades.ts
+++ b/prisma/seeds/seed-cuidades.ts
@@ -1,0 +1,11 @@
+// prisma/seeds/ciudades.seed.ts
+import { PrismaClient } from '@prisma/client';
+import { ciudades } from '../data/ciudades';
+
+export async function seedCiudades(prisma: PrismaClient) {
+  await prisma.ciudad.createMany({
+    data: ciudades,
+  });
+  
+  console.log(`✅ Creadas ${ciudades.length} ciudades`);
+}

--- a/prisma/seeds/seed-modelo-buses-tipos-de-asientos.ts
+++ b/prisma/seeds/seed-modelo-buses-tipos-de-asientos.ts
@@ -1,0 +1,289 @@
+// prisma/seeds/modelos-buses.seed.ts
+import { PrismaClient } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+
+export async function seedModelosBuses(prisma: PrismaClient, tenants: any[]) {
+  // Crear tipos de asientos para cada tenant
+  const tiposAsiento = [];
+  for (let i = 0; i < tenants.length; i++) {
+    const tenant = tenants[i];
+    
+    if (i === 0) { // Flota Pelileo
+      tiposAsiento.push(
+        await prisma.tipoAsiento.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Ejecutivo',
+            descripcion: 'Asiento ejecutivo con mayor comodidad',
+            factorPrecio: new Decimal('1.50'),
+            color: '#1E40AF',
+            icono: 'executive-seat',
+          },
+        }),
+        await prisma.tipoAsiento.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Económico',
+            descripcion: 'Asiento estándar económico',
+            factorPrecio: new Decimal('1.00'),
+            color: '#6B7280',
+            icono: 'standard-seat',
+          },
+        })
+      );
+    } else if (i === 1) { // Transportes Baños
+      tiposAsiento.push(
+        await prisma.tipoAsiento.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'VIP',
+            descripcion: 'Asiento VIP con servicios premium',
+            factorPrecio: new Decimal('2.00'),
+            color: '#059669',
+            icono: 'vip-seat',
+          },
+        }),
+        await prisma.tipoAsiento.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Regular',
+            descripcion: 'Asiento regular',
+            factorPrecio: new Decimal('1.00'),
+            color: '#9CA3AF',
+            icono: 'regular-seat',
+          },
+        })
+      );
+    } else { // Expreso Riobamba
+      tiposAsiento.push(
+        await prisma.tipoAsiento.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Premium',
+            descripcion: 'Asiento premium de lujo',
+            factorPrecio: new Decimal('1.75'),
+            color: '#7C2D12',
+            icono: 'premium-seat',
+          },
+        }),
+        await prisma.tipoAsiento.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Estándar',
+            descripcion: 'Asiento estándar cómodo',
+            factorPrecio: new Decimal('1.00'),
+            color: '#94A3B8',
+            icono: 'standard-seat',
+          },
+        })
+      );
+    }
+  }
+
+  // Crear modelos de bus más variados
+  const modelosBus = await Promise.all([
+    // Buses de 1 piso - configuración 2+2
+    prisma.modeloBus.create({
+      data: {
+        marca: 'Mercedes-Benz',
+        modelo: 'OF-1721',
+        tipoChasis: 'Chasis largo',
+        tipoCarroceria: 'Carrocería Urbano',
+        anioModelo: 2020,
+        numeroPisos: 1,
+        descripcion: 'Bus interprovincial de alta gama - 44 asientos',
+        esPublico: true,
+      },
+    }),
+    // Buses de 1 piso - configuración 2+1
+    prisma.modeloBus.create({
+      data: {
+        marca: 'Chevrolet',
+        modelo: 'NPR',
+        tipoChasis: 'Chasis mediano',
+        tipoCarroceria: 'Carrocería Mixta',
+        anioModelo: 2019,
+        numeroPisos: 1,
+        descripcion: 'Bus para rutas intercantonales - 36 asientos',
+        esPublico: true,
+      },
+    }),
+    // Buses de 2 pisos
+    prisma.modeloBus.create({
+      data: {
+        marca: 'Volvo',
+        modelo: 'B7R',
+        tipoChasis: 'Chasis premium',
+        tipoCarroceria: 'Carrocería Ejecutiva',
+        anioModelo: 2021,
+        numeroPisos: 2,
+        descripcion: 'Bus de dos pisos para rutas largas - 68 asientos',
+        esPublico: true,
+      },
+    }),
+    // Bus compacto
+    prisma.modeloBus.create({
+      data: {
+        marca: 'Isuzu',
+        modelo: 'FRR',
+        tipoChasis: 'Chasis compacto',
+        tipoCarroceria: 'Carrocería Turística',
+        anioModelo: 2020,
+        numeroPisos: 1,
+        descripcion: 'Bus compacto para rutas turísticas - 30 asientos',
+        esPublico: true,
+      },
+    }),
+    // Bus ejecutivo
+    prisma.modeloBus.create({
+      data: {
+        marca: 'Scania',
+        modelo: 'K320',
+        tipoChasis: 'Chasis premium',
+        tipoCarroceria: 'Carrocería Ejecutiva',
+        anioModelo: 2022,
+        numeroPisos: 1,
+        descripcion: 'Bus ejecutivo de lujo - 40 asientos',
+        esPublico: true,
+      },
+    }),
+    // Bus económico
+    prisma.modeloBus.create({
+      data: {
+        marca: 'Hyundai',
+        modelo: 'Universe',
+        tipoChasis: 'Chasis estándar',
+        tipoCarroceria: 'Carrocería Estándar',
+        anioModelo: 2019,
+        numeroPisos: 1,
+        descripcion: 'Bus económico para rutas urbanas - 42 asientos',
+        esPublico: true,
+      },
+    }),
+  ]);
+
+  // Crear plantillas de piso
+  const plantillasPiso = await Promise.all([
+    // Mercedes-Benz OF-1721 (1 piso, 2+2)
+    prisma.plantillaPiso.create({
+      data: {
+        modeloBusId: modelosBus[0].id,
+        numeroPiso: 1,
+        filas: 11,
+        columnas: 4,
+        descripcion: 'Configuración estándar 11x4 - 44 asientos',
+        esPublico: true,
+      },
+    }),
+    // Chevrolet NPR (1 piso, 2+1)
+    prisma.plantillaPiso.create({
+      data: {
+        modeloBusId: modelosBus[1].id,
+        numeroPiso: 1,
+        filas: 12,
+        columnas: 3,
+        descripcion: 'Configuración compacta 12x3 - 36 asientos',
+        esPublico: true,
+      },
+    }),
+    // Volvo B7R (2 pisos)
+    prisma.plantillaPiso.create({
+      data: {
+        modeloBusId: modelosBus[2].id,
+        numeroPiso: 1,
+        filas: 8,
+        columnas: 4,
+        descripcion: 'Piso inferior 8x4 - 32 asientos',
+        esPublico: true,
+      },
+    }),
+    prisma.plantillaPiso.create({
+      data: {
+        modeloBusId: modelosBus[2].id,
+        numeroPiso: 2,
+        filas: 9,
+        columnas: 4,
+        descripcion: 'Piso superior 9x4 - 36 asientos',
+        esPublico: true,
+      },
+    }),
+    // Isuzu FRR (1 piso, compacto)
+    prisma.plantillaPiso.create({
+      data: {
+        modeloBusId: modelosBus[3].id,
+        numeroPiso: 1,
+        filas: 10,
+        columnas: 3,
+        descripcion: 'Configuración compacta 10x3 - 30 asientos',
+        esPublico: true,
+      },
+    }),
+    // Scania K320 (1 piso, ejecutivo)
+    prisma.plantillaPiso.create({
+      data: {
+        modeloBusId: modelosBus[4].id,
+        numeroPiso: 1,
+        filas: 10,
+        columnas: 4,
+        descripcion: 'Configuración ejecutiva 10x4 - 40 asientos',
+        esPublico: true,
+      },
+    }),
+    // Hyundai Universe (1 piso, económico)
+    prisma.plantillaPiso.create({
+      data: {
+        modeloBusId: modelosBus[5].id,
+        numeroPiso: 1,
+        filas: 10,
+        columnas: 4,
+        descripcion: 'Configuración económica 10x4 - 40 asientos (2 asientos adicionales)',
+        esPublico: true,
+      },
+    }),
+  ]);
+
+  // Crear ubicaciones de asientos en plantillas
+  for (const plantilla of plantillasPiso) {
+    const ubicaciones = [];
+    for (let fila = 1; fila <= plantilla.filas; fila++) {
+      if (plantilla.columnas === 3) {
+        // Configuración 2+1 (pasillo después de columna 2)
+        for (let columna = 1; columna <= 3; columna++) {
+          if (columna === 3) {
+            // Solo 1 asiento al lado derecho
+            ubicaciones.push({
+              plantillaPisoId: plantilla.id,
+              fila,
+              columna: 3,
+              estaHabilitado: true,
+            });
+          } else {
+            // 2 asientos al lado izquierdo
+            ubicaciones.push({
+              plantillaPisoId: plantilla.id,
+              fila,
+              columna,
+              estaHabilitado: true,
+            });
+          }
+        }
+      } else {
+        // Configuración 2+2 (pasillo entre columnas 2 y 3)
+        for (let columna = 1; columna <= 4; columna++) {
+          ubicaciones.push({
+            plantillaPisoId: plantilla.id,
+            fila,
+            columna,
+            estaHabilitado: true,
+          });
+        }
+      }
+    }
+    
+    await prisma.ubicacionAsientoPlantilla.createMany({
+      data: ubicaciones,
+    });
+  }
+
+  return { modelosBus, plantillasPiso, tiposAsiento };
+}

--- a/prisma/seeds/seed-ruta-horario.ts
+++ b/prisma/seeds/seed-ruta-horario.ts
@@ -1,0 +1,305 @@
+// prisma/seeds/rutas.seed.ts
+import { PrismaClient } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+
+export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
+  // Crear resoluciones ANT
+  const resolucionesANT = await Promise.all([
+    prisma.resolucionANT.create({
+      data: {
+        numeroResolucion: 'ANT-2025-001',
+        fechaEmision: new Date('2025-01-15'),
+        fechaVigencia: new Date('2028-01-15'),
+        documentoUrl: 'https://www.ant.gob.ec/wp-content/uploads/2025/01/Reglamento_Homologacion_Tecnica_sistemas_Pos_Satelital.pdf',
+        descripcion: 'Resolución para rutas interprovinciales zona central',
+        activo: true,
+      },
+    }),
+    prisma.resolucionANT.create({
+      data: {
+        numeroResolucion: 'ANT-2025-002',
+        fechaEmision: new Date('2025-02-20'),
+        fechaVigencia: new Date('2028-02-20'),
+        documentoUrl: 'https://www.ant.gob.ec/wp-content/uploads/2025/01/Reglamento_Homologacion_Tecnica_sistemas_Pos_Satelital.pdf',
+        descripcion: 'Resolución para rutas turísticas zona sierra',
+        activo: true,
+      },
+    }),
+    prisma.resolucionANT.create({
+      data: {
+        numeroResolucion: 'ANT-2025-003',
+        fechaEmision: new Date('2025-03-10'),
+        fechaVigencia: new Date('2028-03-10'),
+        documentoUrl: 'https://www.ant.gob.ec/wp-content/uploads/2025/01/Reglamento_Homologacion_Tecnica_sistemas_Pos_Satelital.pdf',
+        descripcion: 'Resolución para rutas intercantonales',
+        activo: true,
+      },
+    }),
+  ]);
+
+  // Obtener ciudades necesarias
+  const ciudades = await prisma.ciudad.findMany();
+  const getCiudadByName = (nombre: string) => ciudades.find(c => c.nombre === nombre);
+
+  const rutas = [];
+
+  // RUTAS PARA FLOTA PELILEO (5 rutas)
+  const rutasFlotaPelileo = [
+    {
+      nombre: 'Pelileo - Ambato - Quito',
+      descripcion: 'Ruta interprovincial desde Pelileo hasta Quito con parada en Ambato',
+      paradas: [
+        { ciudad: 'Pelileo', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Ambato', orden: 1, distancia: 18.5, tiempo: 25, precio: 1.5 },
+        { ciudad: 'Quito', orden: 2, distancia: 158.3, tiempo: 180, precio: 8.5 },
+      ],
+      horarios: [
+        { hora: '06:00', dias: '1111111' },
+        { hora: '14:30', dias: '1111111' },
+      ],
+    },
+    {
+      nombre: 'Pelileo - Riobamba',
+      descripcion: 'Ruta intercantonal directa desde Pelileo hasta Riobamba',
+      paradas: [
+        { ciudad: 'Pelileo', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Riobamba', orden: 1, distancia: 65.2, tiempo: 90, precio: 3.5 },
+      ],
+      horarios: [
+        { hora: '08:00', dias: '1111100' },
+        { hora: '16:00', dias: '1111100' },
+      ],
+    },
+    {
+      nombre: 'Pelileo - Latacunga - Quito',
+      descripcion: 'Ruta alternativa hacia Quito vía Latacunga',
+      paradas: [
+        { ciudad: 'Pelileo', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Ambato', orden: 1, distancia: 18.5, tiempo: 25, precio: 1.5 },
+        { ciudad: 'Latacunga', orden: 2, distancia: 65.8, tiempo: 85, precio: 3.2 },
+        { ciudad: 'Quito', orden: 3, distancia: 158.3, tiempo: 180, precio: 8.5 },
+      ],
+      horarios: [
+        { hora: '10:00', dias: '0000011' },
+      ],
+    },
+    {
+      nombre: 'Pelileo - Cuenca',
+      descripcion: 'Ruta hacia el sur del país',
+      paradas: [
+        { ciudad: 'Pelileo', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Riobamba', orden: 1, distancia: 65.2, tiempo: 90, precio: 3.5 },
+        { ciudad: 'Azogues', orden: 2, distancia: 155.3, tiempo: 210, precio: 7.8 },
+        { ciudad: 'Cuenca', orden: 3, distancia: 175.6, tiempo: 240, precio: 9.2 },
+      ],
+      horarios: [
+        { hora: '07:30', dias: '1111111' },
+        { hora: '15:00', dias: '1111111' },
+      ],
+    },
+    {
+      nombre: 'Ambato - Guaranda',
+      descripcion: 'Ruta intercantonal hacia Bolívar',
+      paradas: [
+        { ciudad: 'Ambato', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Guaranda', orden: 1, distancia: 62.4, tiempo: 95, precio: 3.8 },
+      ],
+      horarios: [
+        { hora: '09:30', dias: '1111100' },
+      ],
+    },
+  ];
+
+  // RUTAS PARA TRANSPORTES BAÑOS (5 rutas)
+  const rutasTransportesBanos = [
+    {
+      nombre: 'Baños - Puyo - Tena',
+      descripcion: 'Ruta turística amazónica desde Baños hasta Tena',
+      paradas: [
+        { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Puyo', orden: 1, distancia: 61.4, tiempo: 75, precio: 2.75 },
+        { ciudad: 'Tena', orden: 2, distancia: 167.8, tiempo: 195, precio: 6.25 },
+      ],
+      horarios: [
+        { hora: '07:30', dias: '1111111' },
+        { hora: '15:00', dias: '0000011' },
+      ],
+    },
+    {
+      nombre: 'Baños - Ambato - Latacunga',
+      descripcion: 'Ruta interprovincial hacia el norte',
+      paradas: [
+        { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Ambato', orden: 1, distancia: 42.3, tiempo: 55, precio: 2.25 },
+        { ciudad: 'Latacunga', orden: 2, distancia: 89.6, tiempo: 120, precio: 4.5 },
+      ],
+      horarios: [
+        { hora: '09:15', dias: '1111111' },
+        { hora: '17:45', dias: '1111111' },
+      ],
+    },
+    {
+      nombre: 'Baños - Riobamba - Alausí',
+      descripcion: 'Ruta turística hacia la Nariz del Diablo',
+      paradas: [
+        { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Riobamba', orden: 1, distancia: 85.7, tiempo: 110, precio: 4.2 },
+        { ciudad: 'Alausí', orden: 2, distancia: 142.3, tiempo: 180, precio: 7.1 },
+      ],
+      horarios: [
+        { hora: '08:00', dias: '1111111' },
+        { hora: '14:30', dias: '0000011' },
+      ],
+    },
+    {
+      nombre: 'Baños - Quito',
+      descripcion: 'Ruta directa hacia la capital',
+      paradas: [
+        { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Ambato', orden: 1, distancia: 42.3, tiempo: 55, precio: 2.25 },
+        { ciudad: 'Latacunga', orden: 2, distancia: 89.6, tiempo: 120, precio: 4.5 },
+        { ciudad: 'Machachi', orden: 3, distancia: 135.2, tiempo: 160, precio: 6.8 },
+        { ciudad: 'Quito', orden: 4, distancia: 185.4, tiempo: 220, precio: 9.3 },
+      ],
+      horarios: [
+        { hora: '06:00', dias: '1111111' },
+      ],
+    },
+    {
+      nombre: 'Baños - Shell',
+      descripcion: 'Ruta corta hacia Shell Mera',
+      paradas: [
+        { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Shell', orden: 1, distancia: 18.2, tiempo: 25, precio: 1.25 },
+      ],
+      horarios: [
+        { hora: '11:00', dias: '1111111' },
+        { hora: '16:30', dias: '1111111' },
+      ],
+    },
+  ];
+
+  // RUTAS PARA EXPRESO RIOBAMBA (5 rutas)
+  const rutasExpresoRiobamba = [
+    {
+      nombre: 'Riobamba - Guayaquil',
+      descripcion: 'Ruta interprovincial hacia la costa',
+      paradas: [
+        { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Alausí', orden: 1, distancia: 56.6, tiempo: 75, precio: 2.8 },
+        { ciudad: 'La Troncal', orden: 2, distancia: 142.8, tiempo: 180, precio: 7.1 },
+        { ciudad: 'Milagro', orden: 3, distancia: 198.5, tiempo: 240, precio: 9.9 },
+        { ciudad: 'Guayaquil', orden: 4, distancia: 243.7, tiempo: 290, precio: 12.2 },
+      ],
+      horarios: [
+        { hora: '05:30', dias: '1111111' },
+        { hora: '22:00', dias: '1111111' },
+      ],
+    },
+    {
+      nombre: 'Riobamba - Quito',
+      descripcion: 'Ruta directa hacia la capital',
+      paradas: [
+        { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Ambato', orden: 1, distancia: 47.2, tiempo: 65, precio: 2.4 },
+        { ciudad: 'Latacunga', orden: 2, distancia: 94.5, tiempo: 125, precio: 4.7 },
+        { ciudad: 'Quito', orden: 3, distancia: 198.8, tiempo: 240, precio: 9.9 },
+      ],
+      horarios: [
+        { hora: '07:00', dias: '1111111' },
+        { hora: '15:30', dias: '1111111' },
+      ],
+    },
+    {
+      nombre: 'Riobamba - Cuenca',
+      descripcion: 'Ruta hacia la región austral',
+      paradas: [
+        { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Azogues', orden: 1, distancia: 90.1, tiempo: 120, precio: 4.5 },
+        { ciudad: 'Cuenca', orden: 2, distancia: 110.4, tiempo: 150, precio: 5.5 },
+      ],
+      horarios: [
+        { hora: '08:30', dias: '1111111' },
+        { hora: '16:00', dias: '1111111' },
+      ],
+    },
+    {
+      nombre: 'Riobamba - Macas',
+      descripcion: 'Ruta hacia la amazonia sur',
+      paradas: [
+        { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Macas', orden: 1, distancia: 142.6, tiempo: 210, precio: 7.1 },
+      ],
+      horarios: [
+        { hora: '06:30', dias: '1111100' },
+      ],
+    },
+    {
+      nombre: 'Riobamba - Guaranda - Babahoyo',
+      descripcion: 'Ruta hacia Los Ríos vía Guaranda',
+      paradas: [
+        { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
+        { ciudad: 'Guaranda', orden: 1, distancia: 68.3, tiempo: 85, precio: 3.4 },
+        { ciudad: 'Babahoyo', orden: 2, distancia: 156.7, tiempo: 195, precio: 7.8 },
+      ],
+      horarios: [
+        { hora: '10:00', dias: '1111100' },
+        { hora: '18:00', dias: '0000011' },
+      ],
+    },
+  ];
+
+  // Crear rutas para cada tenant
+  const allRutas = [rutasFlotaPelileo, rutasTransportesBanos, rutasExpresoRiobamba];
+  
+  for (let tenantIndex = 0; tenantIndex < tenants.length; tenantIndex++) {
+    const tenant = tenants[tenantIndex];
+    const rutasTenant = allRutas[tenantIndex];
+    
+    for (const rutaData of rutasTenant) {
+      // Crear la ruta
+      const ruta = await prisma.ruta.create({
+        data: {
+          tenantId: tenant.id,
+          nombre: rutaData.nombre,
+          resolucionId: resolucionesANT[tenantIndex % resolucionesANT.length].id,
+          descripcion: rutaData.descripcion,
+          activo: true,
+        },
+      });
+      rutas.push(ruta);
+
+      // Crear paradas de la ruta
+      for (const paradaData of rutaData.paradas) {
+        const ciudad = getCiudadByName(paradaData.ciudad);
+        if (ciudad) {
+          await prisma.paradaRuta.create({
+            data: {
+              rutaId: ruta.id,
+              ciudadId: ciudad.id,
+              orden: paradaData.orden,
+              distanciaAcumulada: new Decimal(paradaData.distancia.toString()),
+              tiempoAcumulado: paradaData.tiempo,
+              precioAcumulado: new Decimal(paradaData.precio.toString()),
+            },
+          });
+        }
+      }
+
+      // Crear horarios de la ruta
+      for (const horarioData of rutaData.horarios) {
+        await prisma.horarioRuta.create({
+          data: {
+            rutaId: ruta.id,
+            horaSalida: horarioData.hora,
+            diasSemana: horarioData.dias,
+            activo: true,
+          },
+        });
+      }
+    }
+  }
+
+  console.log(`✅ Creadas ${rutas.length} rutas con sus paradas y horarios`);
+  return rutas;
+}

--- a/prisma/seeds/seed-tenants.ts
+++ b/prisma/seeds/seed-tenants.ts
@@ -1,0 +1,56 @@
+// prisma/seeds/tenants.seed.ts
+import { PrismaClient, TipoUsuario } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+
+export async function seedTenants(prisma: PrismaClient) {
+  // Crear usuario administrador del sistema
+  const adminSistema = await prisma.usuario.create({
+    data: {
+      username: 'admin',
+      passwordHash: bcrypt.hashSync('admin', 10),
+      tipoUsuario: TipoUsuario.ADMIN_SISTEMA,
+    },
+  });
+
+  // Crear tenants (cooperativas)
+  const tenants = await Promise.all([
+    prisma.tenant.create({
+      data: {
+        nombre: 'Cooperativa Flota Pelileo',
+        identificador: 'flota-pelileo',
+        logoUrl: 'https://example.com/logo-pelileo.png',
+        colorPrimario: '#1E40AF',
+        colorSecundario: '#F59E0B',
+        sitioWeb: 'https://flotapelileo.com',
+        emailContacto: 'info@flotapelileo.com',
+        telefono: '+593987654321',
+      },
+    }),
+    prisma.tenant.create({
+      data: {
+        nombre: 'Transportes Baños',
+        identificador: 'transportes-banos',
+        logoUrl: 'https://example.com/logo-banos.png',
+        colorPrimario: '#059669',
+        colorSecundario: '#DC2626',
+        sitioWeb: 'https://transportesbanos.com',
+        emailContacto: 'contacto@transportesbanos.com',
+        telefono: '+593987654322',
+      },
+    }),
+    prisma.tenant.create({
+      data: {
+        nombre: 'Expreso Riobamba',
+        identificador: 'expreso-riobamba',
+        logoUrl: 'https://example.com/logo-riobamba.png',
+        colorPrimario: '#7C2D12',
+        colorSecundario: '#F97316',
+        sitioWeb: 'https://expresoriobamba.com',
+        emailContacto: 'ventas@expresoriobamba.com',
+        telefono: '+593987654323',
+      },
+    }),
+  ]);
+
+  return { adminSistema, tenants };
+}

--- a/prisma/seeds/seed-usuarios-personal.ts
+++ b/prisma/seeds/seed-usuarios-personal.ts
@@ -1,0 +1,195 @@
+// prisma/seeds/usuarios.seed.ts
+import { PrismaClient, TipoUsuario, RolUsuario, TipoDocumento } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+
+export async function seedUsuarios(prisma: PrismaClient, tenants: any[]) {
+  // Crear usuarios del personal para cada tenant
+  const usuariosPersonal = [];
+  const usuariosTenant = [];
+
+  // Para cada cooperativa, crear usuarios con diferentes roles
+  for (let tenantIndex = 0; tenantIndex < tenants.length; tenantIndex++) {
+    const tenant = tenants[tenantIndex];
+    const tenantName = tenant.identificador.split('-')[0]; // flota, transportes, expreso
+
+    // 1 Admin por cooperativa
+    const adminUser = await prisma.usuario.create({
+      data: {
+        username: `admin.${tenantName}`,
+        passwordHash: bcrypt.hashSync('password123', 10),
+        tipoUsuario: TipoUsuario.PERSONAL_COOPERATIVA,
+      },
+    });
+    usuariosPersonal.push(adminUser);
+
+    const adminTenant = await prisma.usuarioTenant.create({
+      data: {
+        usuarioId: adminUser.id,
+        tenantId: tenant.id,
+        rol: RolUsuario.ADMIN_COOPERATIVA,
+      },
+    });
+    usuariosTenant.push(adminTenant);
+
+    // 2 Oficinistas por cooperativa
+    for (let i = 1; i <= 2; i++) {
+      const oficinistaUser = await prisma.usuario.create({
+        data: {
+          username: `oficinista${i}.${tenantName}`,
+          passwordHash: bcrypt.hashSync('password123', 10),
+          tipoUsuario: TipoUsuario.PERSONAL_COOPERATIVA,
+        },
+      });
+      usuariosPersonal.push(oficinistaUser);
+
+      const oficinistaTenant = await prisma.usuarioTenant.create({
+        data: {
+          usuarioId: oficinistaUser.id,
+          tenantId: tenant.id,
+          rol: RolUsuario.OFICINISTA,
+        },
+      });
+      usuariosTenant.push(oficinistaTenant);
+    }
+
+    // 10 Conductores por cooperativa
+    const conductorNames = [
+      'Juan', 'Carlos', 'Luis', 'Miguel', 'Roberto', 
+      'Pedro', 'Jorge', 'Francisco', 'Rafael', 'Antonio'
+    ];
+    
+    for (let i = 0; i < 10; i++) {
+      const conductorUser = await prisma.usuario.create({
+        data: {
+          username: `${conductorNames[i].toLowerCase()}.conductor.${tenantName}`,
+          passwordHash: bcrypt.hashSync('password123', 10),
+          tipoUsuario: TipoUsuario.PERSONAL_COOPERATIVA,
+        },
+      });
+      usuariosPersonal.push(conductorUser);
+
+      const conductorTenant = await prisma.usuarioTenant.create({
+        data: {
+          usuarioId: conductorUser.id,
+          tenantId: tenant.id,
+          rol: RolUsuario.CONDUCTOR,
+        },
+      });
+      usuariosTenant.push(conductorTenant);
+    }
+
+    // 10 Ayudantes por cooperativa
+    const ayudanteNames = [
+      'David', 'Andrés', 'Sebastián', 'Mario', 'Daniel',
+      'Cristian', 'Eduardo', 'Patricio', 'Rodrigo', 'Héctor'
+    ];
+    
+    for (let i = 0; i < 10; i++) {
+      const ayudanteUser = await prisma.usuario.create({
+        data: {
+          username: `${ayudanteNames[i].toLowerCase()}.ayudante.${tenantName}`,
+          passwordHash: bcrypt.hashSync('password123', 10),
+          tipoUsuario: TipoUsuario.PERSONAL_COOPERATIVA,
+        },
+      });
+      usuariosPersonal.push(ayudanteUser);
+
+      const ayudanteTenant = await prisma.usuarioTenant.create({
+        data: {
+          usuarioId: ayudanteUser.id,
+          tenantId: tenant.id,
+          rol: RolUsuario.AYUDANTE,
+        },
+      });
+      usuariosTenant.push(ayudanteTenant);
+    }
+  }
+
+  // Crear información personal para algunos usuarios (ejemplo para los admins y algunos conductores)
+  const personalInfo = [
+    // Admins
+    {
+      usuarioTenantId: usuariosTenant[0].id, // Admin Flota Pelileo
+      nombres: 'Miguel Antonio',
+      apellidos: 'Pérez González',
+      tipoDocumento: TipoDocumento.CEDULA,
+      numeroDocumento: '1804567890',
+      telefono: '+593987123456',
+      email: 'miguel.perez@flotapelileo.com',
+      fechaNacimiento: new Date('1980-05-15'),
+      direccion: 'Av. Amazonas 123, Pelileo',
+      ciudadResidencia: 'Pelileo',
+      genero: 'M',
+      fechaContratacion: new Date('2020-01-01'),
+    },
+    {
+      usuarioTenantId: usuariosTenant[13].id, // Admin Transportes Baños
+      nombres: 'Ana María',
+      apellidos: 'Rodríguez Vásquez',
+      tipoDocumento: TipoDocumento.CEDULA,
+      numeroDocumento: '1804567891',
+      telefono: '+593987123457',
+      email: 'ana.rodriguez@transportesbanos.com',
+      fechaNacimiento: new Date('1982-08-22'),
+      direccion: 'Calle Bolívar 456, Baños',
+      ciudadResidencia: 'Baños',
+      genero: 'F',
+      fechaContratacion: new Date('2019-03-01'),
+    },
+    {
+      usuarioTenantId: usuariosTenant[26].id, // Admin Expreso Riobamba
+      nombres: 'Carlos Eduardo',
+      apellidos: 'Morales Castro',
+      tipoDocumento: TipoDocumento.CEDULA,
+      numeroDocumento: '1804567892',
+      telefono: '+593987123458',
+      email: 'carlos.morales@expresoriobamba.com',
+      fechaNacimiento: new Date('1978-12-10'),
+      direccion: 'Av. Los Libertadores 789, Riobamba',
+      ciudadResidencia: 'Riobamba',
+      genero: 'M',
+      fechaContratacion: new Date('2018-06-01'),
+    },
+    // Algunos conductores con licencias
+    {
+      usuarioTenantId: usuariosTenant[3].id, // Primer conductor Flota Pelileo
+      nombres: 'Juan Carlos',
+      apellidos: 'Morales Vásquez',
+      tipoDocumento: TipoDocumento.CEDULA,
+      numeroDocumento: '1804567893',
+      telefono: '+593987123459',
+      email: 'juan.morales@flotapelileo.com',
+      fechaNacimiento: new Date('1975-08-22'),
+      direccion: 'Calle Sucre 321, Pelileo',
+      ciudadResidencia: 'Pelileo',
+      genero: 'M',
+      licenciaConducir: 'C1-123456789',
+      tipoLicencia: 'C1',
+      fechaExpiracionLicencia: new Date('2025-08-22'),
+      fechaContratacion: new Date('2018-03-01'),
+    },
+    {
+      usuarioTenantId: usuariosTenant[16].id, // Primer conductor Transportes Baños
+      nombres: 'Carlos Alberto',
+      apellidos: 'Jiménez Ruiz',
+      tipoDocumento: TipoDocumento.CEDULA,
+      numeroDocumento: '1804567894',
+      telefono: '+593987123460',
+      email: 'carlos.jimenez@transportesbanos.com',
+      fechaNacimiento: new Date('1973-11-15'),
+      direccion: 'Av. Montalvo 654, Baños',
+      ciudadResidencia: 'Baños',
+      genero: 'M',
+      licenciaConducir: 'C1-987654321',
+      tipoLicencia: 'C1',
+      fechaExpiracionLicencia: new Date('2026-11-15'),
+      fechaContratacion: new Date('2017-09-01'),
+    },
+  ];
+
+  await prisma.personalCooperativa.createMany({
+    data: personalInfo,
+  });
+
+  return { usuariosPersonal, usuariosTenant };
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { ResolucionesAntModule } from './modules/resoluciones-ant/resoluciones-a
 import { RutasModule } from './modules/rutas/rutas.module';
 import { ParadasRutaModule } from './modules/paradas-ruta/paradas-ruta.module';
 import { HorariosRutaModule } from './modules/horarios-ruta/horarios-ruta.module';
+import { ViajesModule } from './modules/viajes/viajes.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { HorariosRutaModule } from './modules/horarios-ruta/horarios-ruta.module
     RutasModule,
     ParadasRutaModule,
     HorariosRutaModule,
+    ViajesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/paradas-ruta/constants/parada-ruta-select.ts
+++ b/src/modules/paradas-ruta/constants/parada-ruta-select.ts
@@ -19,3 +19,14 @@ export const PARADA_RUTA_SELECT_WITH_RELATIONS: Prisma.ParadaRutaSelect = {
     },
   },
 }; 
+
+export const PARADA_RUTA_SELECT_WITH_RELATIONS_WITH_CIUDAD: Prisma.ParadaRutaSelect = {
+  id: true,
+  orden: true,
+  ciudad: {
+    select: {
+      id: true,
+      nombre: true,
+    },
+  },
+};

--- a/src/modules/rutas/constants/ruta-select.ts
+++ b/src/modules/rutas/constants/ruta-select.ts
@@ -24,3 +24,5 @@ export const RUTA_SELECT_WITH_RELATIONS: Prisma.RutaSelect = {
     },
   },
 };
+
+

--- a/src/modules/viajes/constants/viaje-select.ts
+++ b/src/modules/viajes/constants/viaje-select.ts
@@ -1,0 +1,80 @@
+import { Prisma } from '@prisma/client';
+
+export const VIAJE_SELECT: Prisma.ViajeSelect = {
+  id: true,
+  tenantId: true,
+  conductorId: true,
+  ayudanteId: true,
+  fecha: true,
+  horaSalidaReal: true,
+  estado: true,
+  observaciones: true,
+  capacidadTotal: true,
+  asientosOcupados: true,
+  generacion: true,
+};
+
+export const VIAJE_SELECT_WITH_RELATIONS: Prisma.ViajeSelect = {
+  ...VIAJE_SELECT,
+  horarioRuta: {
+    select: {
+      id: true,
+      horaSalida: true,
+      ruta: {
+        select: {
+          id: true,
+          nombre: true,
+          descripcion: true,
+        },
+      },
+    },
+  },
+  bus: {
+    select: {
+      id: true,
+      numero: true,
+      placa: true,
+      totalAsientos: true,
+    },
+  },
+};
+
+export const VIAJE_SELECT_WITH_RELATIONS_WITH_PARADAS: Prisma.ViajeSelect = {
+  ...VIAJE_SELECT,
+  horarioRuta: {
+    select: {
+      id: true,
+      horaSalida: true,
+      ruta: {
+        select: {
+          id: true,
+          nombre: true,
+          descripcion: true,
+          paradas: {
+            select: {
+              id: true,
+              tiempoAcumulado: true,
+              orden: true,
+              precioAcumulado: true,
+              ciudad: {
+                select: {
+                  id: true,
+                  nombre: true,
+                  provincia: true
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  bus: {
+    select: {
+      id: true,
+      numero: true,
+      placa: true,
+      totalAsientos: true,
+    },
+  },
+};

--- a/src/modules/viajes/dto/create-viaje.dto.ts
+++ b/src/modules/viajes/dto/create-viaje.dto.ts
@@ -1,0 +1,84 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsDateString,
+  IsDate,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { EstadoViaje, TipoGeneracion } from '@prisma/client';
+
+export class CreateViajeDto {
+  @ApiProperty({
+    description: 'ID del horario de ruta',
+    example: 1,
+  })
+  @IsInt({ message: 'El ID del horario de ruta debe ser un número entero' })
+  @IsNotEmpty({ message: 'El ID del horario de ruta es requerido' })
+  horarioRutaId: number;
+
+  @ApiProperty({
+    description: 'ID del bus asignado al viaje',
+    example: 1,
+  })
+  @IsInt({ message: 'El ID del bus debe ser un número entero' })
+  @IsNotEmpty({ message: 'El ID del bus es requerido' })
+  busId: number;
+
+  @ApiPropertyOptional({
+    description: 'ID del conductor asignado al viaje',
+    example: 1,
+  })
+  @IsOptional()
+  @IsInt({ message: 'El ID del conductor debe ser un número entero' })
+  conductorId?: number;
+
+  @ApiPropertyOptional({
+    description: 'ID del ayudante asignado al viaje',
+    example: 1,
+  })
+  @IsOptional()
+  @IsInt({ message: 'El ID del ayudante debe ser un número entero' })
+  ayudanteId?: number;
+
+  @ApiProperty({
+    description: 'Fecha del viaje',
+    example: new Date(),
+  })
+  @IsDate()
+  @Type(() => Date)
+  @IsNotEmpty({ message: 'La fecha del viaje es requerida' })
+  fecha: Date;
+
+  @ApiPropertyOptional({
+    description: 'Estado del viaje',
+    enum: EstadoViaje,
+    default: EstadoViaje.PROGRAMADO,
+  })
+  @IsOptional()
+  @IsEnum(EstadoViaje, { message: 'El estado debe ser un valor válido' })
+  estado?: EstadoViaje;
+
+  @ApiPropertyOptional({
+    description: 'Observaciones del viaje',
+    example: 'Viaje regular matutino',
+  })
+  @IsOptional()
+  @IsString({ message: 'Las observaciones deben ser una cadena de caracteres' })
+  @MaxLength(500, { message: 'Las observaciones no pueden exceder 500 caracteres' })
+  observaciones?: string;
+
+  @ApiPropertyOptional({
+    description: 'Tipo de generación del viaje',
+    enum: TipoGeneracion,
+    default: TipoGeneracion.MANUAL,
+  })
+  @IsOptional()
+  @IsEnum(TipoGeneracion, { message: 'El tipo de generación debe ser un valor válido' })
+  generacion?: TipoGeneracion;
+} 

--- a/src/modules/viajes/dto/filtro-viaje-publico.dto.ts
+++ b/src/modules/viajes/dto/filtro-viaje-publico.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsInt, IsNumber } from 'class-validator';
+import { FiltroViajeDto } from './filtro-viaje.dto';
+import { Type } from 'class-transformer';
+
+export class FiltroViajePublicoDto extends FiltroViajeDto {
+  @ApiPropertyOptional({
+    description: 'Filtrar por ID de ciudad de origen',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber(
+    { maxDecimalPlaces: 0 },
+    { message: 'El ID de la ciudad de origen debe ser un número entero' },
+  )
+  ciudadOrigenId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por ID de ciudad de destino',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber(
+    { maxDecimalPlaces: 0 },
+    { message: 'El ID de la ciudad de destino debe ser un número entero' },
+  )
+  ciudadDestinoId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por ID de cooperativa',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'El ID de la cooperativa debe ser un número entero' })
+  cooperativaId?: number;
+}

--- a/src/modules/viajes/dto/filtro-viaje.dto.ts
+++ b/src/modules/viajes/dto/filtro-viaje.dto.ts
@@ -1,0 +1,92 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsDateString,
+  IsDate,
+} from 'class-validator';
+import { EstadoViaje, TipoGeneracion } from '@prisma/client';
+
+export class FiltroViajeDto {
+  @ApiPropertyOptional({
+    description: 'Filtrar por ID de ruta',
+  })
+  @IsOptional()
+  @IsInt({ message: 'El ID de la ruta debe ser un número entero' })
+  @Transform(({ value }) => (value ? parseInt(value) : undefined))
+  rutaId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por ID de horario de ruta',
+  })
+  @IsOptional()
+  @IsInt({ message: 'El ID del horario de ruta debe ser un número entero' })
+  @Transform(({ value }) => (value ? parseInt(value) : undefined))
+  horarioRutaId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por ID de bus',
+  })
+  @IsOptional()
+  @IsInt({ message: 'El ID del bus debe ser un número entero' })
+  @Transform(({ value }) => (value ? parseInt(value) : undefined))
+  busId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por ID de conductor',
+  })
+  @IsOptional()
+  @IsInt({ message: 'El ID del conductor debe ser un número entero' })
+  @Transform(({ value }) => (value ? parseInt(value) : undefined))
+  conductorId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por ID de ayudante',
+  })
+  @IsOptional()
+  @IsInt({ message: 'El ID del ayudante debe ser un número entero' })
+  @Transform(({ value }) => (value ? parseInt(value) : undefined))
+  ayudanteId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por fecha específica',
+  })
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  fecha?: Date;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar desde fecha',
+  })
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  fechaDesde?: Date;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar hasta fecha',
+  })
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  fechaHasta?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por estado del viaje',
+    enum: EstadoViaje,
+  })
+  @IsOptional()
+  @IsEnum(EstadoViaje, { message: 'El estado debe ser un valor válido' })
+  estado?: EstadoViaje;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por tipo de generación',
+    enum: TipoGeneracion,
+  })
+  @IsOptional()
+  @IsEnum(TipoGeneracion, { message: 'El tipo de generación debe ser un valor válido' })
+  generacion?: TipoGeneracion;
+} 

--- a/src/modules/viajes/dto/generar-viajes.dto.ts
+++ b/src/modules/viajes/dto/generar-viajes.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDate,
+  IsNotEmpty,
+  IsOptional,
+  IsArray,
+  IsInt,
+  ValidateNested,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+
+export class GenerarViajesDto {
+  @ApiProperty({
+    description: 'Fecha de inicio para la generación de viajes',
+    example: new Date(),
+  })
+  @IsDate({ message: 'La fecha de inicio debe ser una fecha válida' })
+  @Type(() => Date)
+  @IsNotEmpty({ message: 'La fecha de inicio es requerida' })
+  fechaInicio: Date;
+
+  @ApiProperty({
+    description: 'Fecha de fin para la generación de viajes',
+    example: new Date(),
+  })
+  @IsDate({ message: 'La fecha de fin debe ser una fecha válida' })
+  @Type(() => Date)
+  @IsNotEmpty({ message: 'La fecha de fin es requerida' })
+  fechaFin: Date;
+
+  @ApiPropertyOptional({
+    description: 'IDs específicos de rutas a incluir (opcional, si no se especifica se incluyen todas las activas)',
+    type: [Number],
+    example: [1, 2, 3],
+  })
+  @IsOptional()
+  @IsArray({ message: 'Los IDs de rutas deben ser un array' })
+  @IsInt({ each: true, message: 'Cada ID de ruta debe ser un número entero' })
+  rutaIds?: number[];
+
+  @ApiPropertyOptional({
+    description: 'IDs específicos de buses a utilizar (opcional, si no se especifica se usan todos los disponibles)',
+    type: [Number],
+    example: [1, 2, 3],
+  })
+  @IsOptional()
+  @IsArray({ message: 'Los IDs de buses deben ser un array' })
+  @IsInt({ each: true, message: 'Cada ID de bus debe ser un número entero' })
+  busIds?: number[];
+} 

--- a/src/modules/viajes/dto/index.ts
+++ b/src/modules/viajes/dto/index.ts
@@ -1,0 +1,6 @@
+export { CreateViajeDto } from './create-viaje.dto';
+export { UpdateViajeDto } from './update-viaje.dto';
+export { FiltroViajeDto } from './filtro-viaje.dto';
+export { FiltroViajePublicoDto } from './filtro-viaje-publico.dto';
+export { GenerarViajesDto } from './generar-viajes.dto';
+export { ViajeGeneradoDto } from './viaje-generado.dto'; 

--- a/src/modules/viajes/dto/update-viaje.dto.ts
+++ b/src/modules/viajes/dto/update-viaje.dto.ts
@@ -1,0 +1,15 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PartialType } from '@nestjs/swagger';
+import { CreateViajeDto } from './create-viaje.dto';
+import { IsEnum, IsOptional } from 'class-validator';
+import { EstadoViaje } from '@prisma/client';
+
+export class UpdateViajeDto extends PartialType(CreateViajeDto) {
+  @ApiPropertyOptional({
+    description: 'Estado del viaje',
+    enum: EstadoViaje,
+  })
+  @IsOptional()
+  @IsEnum(EstadoViaje, { message: 'El estado debe ser un valor válido' })
+  estado?: EstadoViaje;
+} 

--- a/src/modules/viajes/dto/viaje-generado.dto.ts
+++ b/src/modules/viajes/dto/viaje-generado.dto.ts
@@ -1,0 +1,95 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EstadoViaje, TipoGeneracion } from '@prisma/client';
+
+export class ViajeGeneradoDto {
+  @ApiProperty({
+    description: 'Fecha del viaje',
+    example: new Date(),
+  })
+  fecha: Date;
+
+
+  @ApiProperty({
+    description: 'Información del horario de ruta',
+  })
+  horarioRuta: {
+    id: number;
+    horaSalida: string;
+    ruta: {
+      id: number;
+      nombre: string;
+      descripcion?: string;
+    };
+  };
+
+  @ApiProperty({
+    description: 'Información del bus asignado',
+  })
+  bus: {
+    id: number;
+    numero: number;
+    placa: string;
+    totalAsientos: number;
+  };
+
+  @ApiProperty({
+    description: 'Estado del viaje',
+    enum: EstadoViaje,
+  })
+  estado: EstadoViaje;
+
+  @ApiProperty({
+    description: 'Capacidad total de asientos',
+    example: 45,
+  })
+  capacidadTotal: number;
+
+  @ApiProperty({
+    description: 'Tipo de generación',
+    enum: TipoGeneracion,
+  })
+  generacion: TipoGeneracion;
+
+  @ApiProperty({
+    description: 'ID del viaje',
+    example: 1,
+  })
+  id?: number = null;
+
+  @ApiProperty({
+    description: 'ID del tenant',
+    example: 1,
+  })
+  tenantId: number = null;
+
+  @ApiProperty({
+    description: 'ID del conductor',
+    example: 1,
+  })
+  conductorId?: number = null;
+
+  @ApiProperty({
+    description: 'ID del ayudante',
+    example: 1,
+  })
+  ayudanteId?: number = null;
+
+  @ApiProperty({
+    description: 'Hora de salida real',
+    example: new Date(),
+  })
+  horaSalidaReal?: Date = null;
+
+  @ApiProperty({
+    description: 'Asientos ocupados',
+    example: 10,
+  })
+  asientosOcupados?: number = 0;
+
+  @ApiProperty({
+    description: 'Observaciones',
+    example: 'Observaciones',
+  })
+  observaciones?: string = null;
+}
+

--- a/src/modules/viajes/services/generacion-viajes.service.ts
+++ b/src/modules/viajes/services/generacion-viajes.service.ts
@@ -1,0 +1,305 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  GenerarViajesDto,
+  ViajeGeneradoDto,
+} from '../dto';
+import { EstadoViaje, TipoGeneracion, Prisma } from '@prisma/client';
+import { VIAJE_SELECT_WITH_RELATIONS } from '../constants/viaje-select';
+
+@Injectable()
+export class GeneracionViajesService {
+  constructor(private prisma: PrismaService) {}
+
+ 
+  async previsualizarGeneracion(
+    datos: GenerarViajesDto,
+    tenantId: number,
+  ): Promise<ViajeGeneradoDto[]> {
+    if (datos.fechaInicio > datos.fechaFin) {
+      throw new BadRequestException(
+        'La fecha de inicio no puede ser mayor a la fecha de fin',
+      );
+    }
+
+    const diffTiempo = datos.fechaFin.getTime() - datos.fechaInicio.getTime();
+    const diffDias = Math.ceil(diffTiempo / (1000 * 3600 * 24));
+
+    if (diffDias > 90) {
+      throw new BadRequestException(
+        'El rango de fechas no puede ser mayor a 90 días',
+      );
+    }
+
+    const horariosRuta = await this.obtenerHorariosRuta(
+      tenantId,
+      datos.rutaIds,
+    );
+
+    if (horariosRuta.length === 0) {
+      throw new NotFoundException(
+        'No se encontraron horarios de ruta activos para generar viajes',
+      );
+    }
+
+    const buses = await this.obtenerBusesDisponibles(tenantId, datos.busIds);
+
+    if (buses.length === 0) {
+      throw new NotFoundException(
+        'No se encontraron buses disponibles para generar viajes',
+      );
+    }
+
+    if (buses.length < horariosRuta.length) {
+      throw new BadRequestException(
+        `Se necesitan al menos ${horariosRuta.length} buses para cubrir ${horariosRuta.length} horarios de ruta. Actualmente tienes ${buses.length} buses disponibles.`,
+      );
+    }
+
+    const viajesGenerados = await this.generarMatrizViajesConRotacionDiaria(
+      datos,
+      horariosRuta,
+      buses,
+      tenantId,
+      false, 
+    );
+
+    return viajesGenerados;
+  }
+
+  async generarYGuardarViajes(
+    datos: GenerarViajesDto,
+    tenantId: number,
+  ): Promise<ViajeGeneradoDto[]> {
+    return await this.prisma.$transaction(async (tx) => {
+      if (datos.fechaInicio > datos.fechaFin) {
+        throw new BadRequestException(
+          'La fecha de inicio no puede ser mayor a la fecha de fin',
+        );
+      }
+
+      const horariosRuta = await this.obtenerHorariosRuta(
+        tenantId,
+        datos.rutaIds,
+      );
+
+      if (horariosRuta.length === 0) {
+        throw new NotFoundException(
+          'No se encontraron horarios de ruta activos para generar viajes',
+        );
+      }
+
+      const buses = await this.obtenerBusesDisponibles(tenantId, datos.busIds);
+
+      if (buses.length === 0) {
+        throw new NotFoundException(
+          'No se encontraron buses disponibles para generar viajes',
+        );
+      }
+
+      if (buses.length < horariosRuta.length) {
+        throw new BadRequestException(
+          `Se necesitan al menos ${horariosRuta.length} buses para cubrir ${horariosRuta.length} horarios de ruta. Actualmente tienes ${buses.length} buses disponibles.`,
+        );
+      }
+
+      const viajesGenerados = await this.generarMatrizViajesConRotacionDiaria(
+        datos,
+        horariosRuta,
+        buses,
+        tenantId,
+        true, 
+        tx,
+      );
+
+      return viajesGenerados;
+    });
+  }
+
+  private async obtenerHorariosRuta(tenantId: number, rutaIds?: number[]) {
+    const where: Prisma.HorarioRutaWhereInput = {
+      activo: true,
+      ruta: {
+        tenantId,
+        activo: true,
+      },
+    };
+
+    if (rutaIds && rutaIds.length > 0) {
+      where.rutaId = { in: rutaIds };
+    }
+
+    return await this.prisma.horarioRuta.findMany({
+      where,
+      select: {
+        id: true,
+        rutaId: true,
+        horaSalida: true,
+        diasSemana: true,
+        ruta: {
+          select: {
+            id: true,
+            nombre: true,
+            descripcion: true,
+          },
+        },
+      },
+      orderBy: [{ ruta: { nombre: 'asc' } }, { horaSalida: 'asc' }],
+    });
+  }
+
+  private async obtenerBusesDisponibles(tenantId: number, busIds?: number[]) {
+    const where: Prisma.BusWhereInput = {
+      tenantId,
+      estado: 'ACTIVO',
+    };
+
+    if (busIds && busIds.length > 0) {
+      where.id = { in: busIds };
+    }
+
+    return await this.prisma.bus.findMany({
+      where,
+      select: {
+        id: true,
+        numero: true,
+        placa: true,
+        totalAsientos: true,
+      },
+      orderBy: { numero: 'asc' },
+    });
+  }
+
+  private async generarMatrizViajesConRotacionDiaria(
+    datos: GenerarViajesDto,
+    horariosRuta: any[],
+    buses: any[],
+    tenantId: number,
+    guardar: boolean = false,
+    tx?: Prisma.TransactionClient,
+  ): Promise<ViajeGeneradoDto[]> {
+    const viajesGenerados: ViajeGeneradoDto[] = [];
+    const prismaClient = tx || this.prisma;
+
+    const fechas: Date[] = [];
+    const fechaActual = new Date(datos.fechaInicio);
+    const fechaFin = new Date(datos.fechaFin);
+
+    while (fechaActual <= fechaFin) {
+      fechas.push(new Date(fechaActual));
+      fechaActual.setDate(fechaActual.getDate() + 1);
+    }
+
+    const viajesExistentes = await prismaClient.viaje.findMany({
+      where: {
+        tenantId,
+        fecha: {
+          gte: datos.fechaInicio,
+          lte: datos.fechaFin,
+        },
+        horarioRutaId: {
+          in: horariosRuta.map((h) => h.id),
+        },
+      },
+      select: {
+        fecha: true,
+        horarioRutaId: true,
+        busId: true,
+      },
+    });
+
+    const horariosOrdenados = [...horariosRuta].sort((a, b) => {
+      if (a.ruta.nombre !== b.ruta.nombre) {
+        return a.ruta.nombre.localeCompare(b.ruta.nombre);
+      }
+      return a.horaSalida.localeCompare(b.horaSalida);
+    });
+
+    for (let indiceFecha = 0; indiceFecha < fechas.length; indiceFecha++) {
+      const fecha = fechas[indiceFecha];
+      const diaSemana = fecha.getDay() === 0 ? 7 : fecha.getDay(); 
+      const posicionDia = diaSemana - 1; 
+
+      for (let indiceHorario = 0; indiceHorario < horariosOrdenados.length; indiceHorario++) {
+        const horario = horariosOrdenados[indiceHorario];
+
+        if (horario.diasSemana && horario.diasSemana[posicionDia] === '1') {
+          
+          const indiceBusRotado = (indiceHorario + indiceFecha) % buses.length;
+          const busAsignado = buses[indiceBusRotado];
+
+          const yaExiste = viajesExistentes.some(
+            (ve) =>
+              ve.fecha.getTime() === fecha.getTime() &&
+              ve.horarioRutaId === horario.id &&
+              ve.busId === busAsignado.id,
+          );
+
+          const viajeGenerado: ViajeGeneradoDto = {
+            id: null,
+            conductorId: null,
+            ayudanteId: null,
+            horaSalidaReal: null,
+            observaciones: null,
+            estado: EstadoViaje.PROGRAMADO,
+            capacidadTotal: busAsignado.totalAsientos,
+            generacion: TipoGeneracion.AUTOMATICA,
+            tenantId,
+            fecha,
+            horarioRuta: {
+              id: horario.id,
+              horaSalida: horario.horaSalida,
+              ruta: horario.ruta,
+            },
+            bus: busAsignado,
+            
+          };
+
+          if (!guardar) {
+            viajesGenerados.push(viajeGenerado);
+            continue;
+          }
+
+
+          if (guardar && !yaExiste) {
+            const viajeCreado = await prismaClient.viaje.create({
+              data: {
+                tenantId,
+                horarioRutaId: horario.id,
+                busId: busAsignado.id,
+                fecha,
+                estado: EstadoViaje.PROGRAMADO,
+                capacidadTotal: busAsignado.totalAsientos,
+                asientosOcupados: 0,
+                generacion: TipoGeneracion.AUTOMATICA,
+              },
+              select: {
+                ...VIAJE_SELECT_WITH_RELATIONS,
+              }
+            });
+            viajesGenerados.push(viajeCreado as unknown as ViajeGeneradoDto);
+          }
+
+          
+        }
+      }
+    }
+
+    return viajesGenerados.sort((a, b) => {
+      if (a.fecha.getTime() !== b.fecha.getTime()) {
+        return a.fecha.getTime() - b.fecha.getTime();
+      }
+      if (a.horarioRuta.ruta.nombre !== b.horarioRuta.ruta.nombre) {
+        return a.horarioRuta.ruta.nombre.localeCompare(b.horarioRuta.ruta.nombre);
+      }
+
+      return a.horarioRuta.horaSalida.localeCompare(b.horarioRuta.horaSalida);
+    });
+  }
+
+
+}

--- a/src/modules/viajes/services/viajes-publico.service.ts
+++ b/src/modules/viajes/services/viajes-publico.service.ts
@@ -1,0 +1,143 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { FiltroViajePublicoDto } from '../dto/filtro-viaje-publico.dto';
+import { VIAJE_SELECT_WITH_RELATIONS_WITH_PARADAS } from '../constants/viaje-select';
+
+@Injectable()
+export class ViajesPublicoService {
+  constructor(private prisma: PrismaService) {}
+
+
+  private async obtenerViajesConOrigenYDestino(
+    ciudadOrigenId: number,
+    ciudadDestinoId: number,
+    whereConditions: Prisma.ViajeWhereInput,
+  ) {
+    const rutasValidas = await this.prisma.ruta.findMany({
+      where: {
+        AND: [
+          {
+            paradas: {
+              some: {
+                ciudadId: ciudadOrigenId,
+              },
+            },
+          },
+          {
+            paradas: {
+              some: {
+                ciudadId: ciudadDestinoId,
+              },
+            },
+          },
+        ],
+      },
+      include: {
+        paradas: {
+          where: {
+            OR: [
+              { ciudadId: ciudadOrigenId },
+              { ciudadId: ciudadDestinoId },
+            ],
+          },
+          orderBy: { orden: 'asc' },
+        },
+      },
+    });
+
+    const rutaIdsValidas = rutasValidas
+      .filter((ruta) => {
+        const paradaOrigen = ruta.paradas.find(p => p.ciudadId === ciudadOrigenId);
+        const paradaDestino = ruta.paradas.find(p => p.ciudadId === ciudadDestinoId);
+        
+        // Validar que ambas paradas existan y que destino esté después de origen
+        return paradaOrigen && 
+               paradaDestino && 
+               paradaDestino.orden > paradaOrigen.orden;
+      })
+      .map((ruta) => ruta.id);
+
+    if (rutaIdsValidas.length === 0) {
+      return [];
+    }
+
+    const nuevasCondiciones = {
+      ...whereConditions,
+      horarioRuta: {
+        rutaId: {
+          in: rutaIdsValidas,
+        },
+      },
+    };
+
+    return this.prisma.viaje.findMany({
+      where: nuevasCondiciones,
+      select: VIAJE_SELECT_WITH_RELATIONS_WITH_PARADAS,
+      orderBy: [
+        { fecha: 'asc' },
+        { horarioRuta: { horaSalida: 'asc' } },
+      ],
+    });
+  }
+
+  
+  async obtenerViajesConSegmentos(
+    filtro?: Partial<FiltroViajePublicoDto>,
+  ) {
+    const viajes = await this.obtenerViajesConOrigenYDestino(
+      filtro.ciudadOrigenId,
+      filtro.ciudadDestinoId,
+      this.construirFiltrosBasicos(filtro),
+    );
+
+    // Enriquecer con información de segmento (precio y tiempo entre paradas)
+    return viajes.map((viaje: any) => {
+      const paradas = viaje.horarioRuta.ruta.paradas;
+      const paradaOrigen = paradas.find((p: any) => p.ciudad.id === filtro.ciudadOrigenId);
+      const paradaDestino = paradas.find((p: any) => p.ciudad.id === filtro.ciudadDestinoId);
+
+      if (paradaOrigen && paradaDestino) {
+        const precioSegmento = paradaDestino.precioAcumulado - paradaOrigen.precioAcumulado;
+        const tiempoSegmento = paradaDestino.tiempoAcumulado - paradaOrigen.tiempoAcumulado;
+
+        return {
+          ...viaje,
+          precio: precioSegmento,
+          tiempoViaje: tiempoSegmento,
+        };
+      }
+
+      return viaje;
+    });
+  }
+
+  private construirFiltrosBasicos(filtro: FiltroViajePublicoDto): Prisma.ViajeWhereInput {
+    const {
+      ciudadOrigenId,
+      ciudadDestinoId,
+      cooperativaId,
+      ...filtrosBasicos
+    } = filtro;
+
+    const whereConditions: Prisma.ViajeWhereInput = {};
+
+    if (cooperativaId) whereConditions.tenantId = cooperativaId;
+    if (filtrosBasicos.horarioRutaId) whereConditions.horarioRutaId = filtrosBasicos.horarioRutaId;
+    if (filtrosBasicos.busId) whereConditions.busId = filtrosBasicos.busId;
+    if (filtrosBasicos.conductorId) whereConditions.conductorId = filtrosBasicos.conductorId;
+    if (filtrosBasicos.ayudanteId) whereConditions.ayudanteId = filtrosBasicos.ayudanteId;
+    if (filtrosBasicos.estado) whereConditions.estado = filtrosBasicos.estado;
+    if (filtrosBasicos.generacion) whereConditions.generacion = filtrosBasicos.generacion;
+
+    if (filtrosBasicos.fecha) {
+      whereConditions.fecha = new Date(filtrosBasicos.fecha);
+    } else if (filtrosBasicos.fechaDesde || filtrosBasicos.fechaHasta) {
+      whereConditions.fecha = {};
+      if (filtrosBasicos.fechaDesde) whereConditions.fecha.gte = new Date(filtrosBasicos.fechaDesde);
+      if (filtrosBasicos.fechaHasta) whereConditions.fecha.lte = new Date(filtrosBasicos.fechaHasta);
+    }
+
+    return whereConditions;
+  }
+} 

--- a/src/modules/viajes/utils/filtro-viaje-build.ts
+++ b/src/modules/viajes/utils/filtro-viaje-build.ts
@@ -1,0 +1,72 @@
+import { Prisma } from '@prisma/client';
+import { FiltroViajeDto } from '../dto/filtro-viaje.dto';
+import { FiltroViajePublicoDto } from '../dto/filtro-viaje-publico.dto';
+
+export const filtroViajeBuild = (
+  filtro: FiltroViajeDto,
+  tenantId?: number,
+): Prisma.ViajeWhereInput => {
+  const where: Prisma.ViajeWhereInput = {};
+
+  if (tenantId) {
+    where.tenantId = tenantId;
+  }
+
+  const {
+    rutaId,
+    horarioRutaId,
+    busId,
+    conductorId,
+    ayudanteId,
+    fecha,
+    fechaDesde,
+    fechaHasta,
+    estado,
+    generacion,
+  } = filtro;
+
+  if (rutaId !== undefined) {
+    where.horarioRuta = {
+      rutaId,
+    };
+  }
+
+  if (horarioRutaId !== undefined) {
+    where.horarioRutaId = horarioRutaId;
+  }
+
+  if (busId !== undefined) {
+    where.busId = busId;
+  }
+
+  if (conductorId !== undefined) {
+    where.conductorId = conductorId;
+  }
+
+  if (ayudanteId !== undefined) {
+    where.ayudanteId = ayudanteId;
+  }
+
+  if (fecha) {
+    where.fecha = new Date(fecha);
+  } else if (fechaDesde || fechaHasta) {
+    where.fecha = {};
+    if (fechaDesde) {
+      where.fecha.gte = new Date(fechaDesde);
+    }
+    if (fechaHasta) {
+      where.fecha.lte = new Date(fechaHasta);
+    }
+  }
+
+  if (estado) {
+    where.estado = estado;
+  }
+
+  if (generacion) {
+    where.generacion = generacion;
+  }
+
+  return where;
+};
+

--- a/src/modules/viajes/viajes.controller.ts
+++ b/src/modules/viajes/viajes.controller.ts
@@ -1,0 +1,280 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Query,
+  ParseIntPipe,
+  HttpStatus,
+  HttpCode,
+  Patch,
+} from '@nestjs/common';
+import { ViajesService } from './viajes.service';
+import { GeneracionViajesService } from './services/generacion-viajes.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { TipoUsuario, RolUsuario, EstadoViaje } from '@prisma/client';
+import { TenantActual } from '../../common/decorators/tenant-actual.decorator';
+import {
+  CreateViajeDto,
+  UpdateViajeDto,
+  FiltroViajeDto,
+  GenerarViajesDto,
+  FiltroViajePublicoDto,
+} from './dto';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { filtroViajeBuild } from './utils/filtro-viaje-build';
+import { ViajesPublicoService } from './services/viajes-publico.service';
+
+@ApiTags('viajes')
+@ApiBearerAuth()
+@Controller('viajes')
+export class ViajesController {
+  constructor(
+    private readonly viajesService: ViajesService,
+    private readonly generacionViajesService: GeneracionViajesService,
+    private readonly viajesPublicoService: ViajesPublicoService,
+  ) {}
+
+  @ApiOperation({
+    summary: 'Obtener viajes con filtros',
+  })
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  async obtenerViajes(
+    @Query() filtro: FiltroViajeDto,
+    @TenantActual() tenantActual,
+  ) {
+    const viajes = await this.viajesService.obtenerViajes(
+      filtroViajeBuild(filtro, tenantActual.id),
+    );
+    return viajes;
+  }
+
+  @ApiOperation({
+    summary: 'Previsualizar la generación de viajes',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Post('generar/previsualizar')
+  @HttpCode(HttpStatus.OK)
+  async previsualizarGeneracion(
+    @Body() generarViajesDto: GenerarViajesDto,
+    @TenantActual() tenantActual,
+  ) {
+    return await this.generacionViajesService.previsualizarGeneracion(
+      generarViajesDto,
+      tenantActual.id,
+    );
+  }
+
+  @ApiOperation({
+    summary: 'Generar y guardar viajes automáticamente',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Post('generar/ejecutar')
+  @HttpCode(HttpStatus.CREATED)
+  async generarYGuardarViajes(
+    @Body() generarViajesDto: GenerarViajesDto,
+    @TenantActual() tenantActual,
+  ) {
+    return await this.generacionViajesService.generarYGuardarViajes(
+      generarViajesDto,
+      tenantActual.id,
+    );
+  }
+
+  @ApiOperation({
+    summary: 'Obtener todos los viajes de todas las cooperativas (Público)',
+  })
+  @Get('publico')
+  async obtenerViajesPublico(@Query() filtro: FiltroViajePublicoDto) {
+    const viajes = await this.viajesPublicoService.obtenerViajesConSegmentos(filtro);
+    return viajes;
+  }
+
+  @ApiOperation({
+    summary: 'Obtener un viaje específico (Público)',
+  })
+  @Get('publico/:id')
+  async obtenerViajePublico(@Param('id', ParseIntPipe) id: number) {
+    const viaje = await this.viajesService.obtenerViaje({ id });
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Obtener un viaje por ID',
+  })
+  @UseGuards(JwtAuthGuard)
+  @Get(':id')
+  async obtenerViajePorId(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.obtenerViaje({
+      id,
+      tenantId: tenantActual.id,
+    });
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Crear un nuevo viaje',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async crearViaje(
+    @Body() createViajeDto: CreateViajeDto,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.crearViaje(
+      createViajeDto,
+      tenantActual.id,
+    );
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Actualizar un viaje',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Put(':id')
+  async actualizarViaje(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateViajeDto: UpdateViajeDto,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.actualizarViaje(
+      id,
+      updateViajeDto,
+      tenantActual.id,
+    );
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Iniciar un viaje (cambiar estado a EN_RUTA)',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(
+    TipoUsuario.ADMIN_SISTEMA,
+    RolUsuario.ADMIN_COOPERATIVA,
+    RolUsuario.CONDUCTOR,
+  )
+  @Patch(':id/iniciar')
+  async iniciarViaje(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.cambiarEstadoViaje(
+      id,
+      EstadoViaje.EN_RUTA,
+      tenantActual.id,
+    );
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Completar un viaje',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(
+    TipoUsuario.ADMIN_SISTEMA,
+    RolUsuario.ADMIN_COOPERATIVA,
+    RolUsuario.CONDUCTOR,
+  )
+  @Patch(':id/completar')
+  async completarViaje(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.cambiarEstadoViaje(
+      id,
+      EstadoViaje.COMPLETADO,
+      tenantActual.id,
+    );
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Cancelar un viaje',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Patch(':id/cancelar')
+  async cancelarViaje(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.cambiarEstadoViaje(
+      id,
+      EstadoViaje.CANCELADO,
+      tenantActual.id,
+    );
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Marcar un viaje como retrasado',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(
+    TipoUsuario.ADMIN_SISTEMA,
+    RolUsuario.ADMIN_COOPERATIVA,
+    RolUsuario.CONDUCTOR,
+  )
+  @Patch(':id/retrasar')
+  async retrasarViaje(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.cambiarEstadoViaje(
+      id,
+      EstadoViaje.RETRASADO,
+      tenantActual.id,
+    );
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Reprogramar un viaje (volver a PROGRAMADO)',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Patch(':id/reprogramar')
+  async reprogramarViaje(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.cambiarEstadoViaje(
+      id,
+      EstadoViaje.PROGRAMADO,
+      tenantActual.id,
+    );
+    return viaje;
+  }
+
+  @ApiOperation({
+    summary: 'Eliminar un viaje',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Delete(':id')
+  async eliminarViaje(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const viaje = await this.viajesService.eliminarViaje(id, tenantActual.id);
+    return viaje;
+  }
+
+} 

--- a/src/modules/viajes/viajes.module.ts
+++ b/src/modules/viajes/viajes.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ViajesController } from './viajes.controller';
+import { ViajesService } from './viajes.service';
+import { GeneracionViajesService } from './services/generacion-viajes.service';
+import { ViajesPublicoService } from './services/viajes-publico.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ViajesController],
+  providers: [ViajesService, GeneracionViajesService, ViajesPublicoService],
+  exports: [ViajesService, GeneracionViajesService, ViajesPublicoService],
+})
+export class ViajesModule {} 

--- a/src/modules/viajes/viajes.service.ts
+++ b/src/modules/viajes/viajes.service.ts
@@ -1,0 +1,370 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { EstadoViaje, Prisma, RolUsuario } from '@prisma/client';
+import { CreateViajeDto, UpdateViajeDto, FiltroViajeDto } from './dto';
+import { VIAJE_SELECT_WITH_RELATIONS, VIAJE_SELECT_WITH_RELATIONS_WITH_PARADAS } from './constants/viaje-select';
+
+@Injectable()
+export class ViajesService {
+  constructor(private prisma: PrismaService) {}
+
+  async obtenerViajes(
+    filtro: Prisma.ViajeWhereInput,
+    args: Prisma.ViajeSelect = VIAJE_SELECT_WITH_RELATIONS,
+  ) {
+    return await this.prisma.viaje.findMany({
+      where: filtro,
+      orderBy: [{ fecha: 'desc' }, { horaSalidaReal: 'asc' }],
+      select: args,
+    });
+  }
+
+  async obtenerViaje(
+    filtro: Prisma.ViajeWhereUniqueInput,
+    args: Prisma.ViajeSelect = VIAJE_SELECT_WITH_RELATIONS_WITH_PARADAS,
+  ) {
+    const viaje = await this.prisma.viaje.findUnique({
+      where: filtro,
+      select: args,
+    });
+
+    if (!viaje) {
+      throw new NotFoundException(
+        `Viaje con el filtro ${JSON.stringify(filtro)} no encontrado`,
+      );
+    }
+
+    return viaje;
+  }
+
+  async crearViaje(
+    datos: CreateViajeDto,
+    tenantId: number,
+    tx?: Prisma.TransactionClient,
+  ) {
+    // Validar que el horario de ruta pertenezca a la ruta
+    const horarioRuta = await this.prisma.horarioRuta.findFirst({
+      where: {
+        id: datos.horarioRutaId,
+        ruta: {
+          tenantId,
+        },
+      },
+    });
+
+    if (!horarioRuta) {
+      throw new NotFoundException(
+        `El horario de ruta con ID ${datos.horarioRutaId} no existe`,
+      );
+    }
+
+    // Validar que el bus pertenezca al tenant
+    const bus = await this.prisma.bus.findUnique({
+      where: { id: datos.busId, tenantId },
+    });
+
+    if (!bus) {
+      throw new NotFoundException(
+        `El bus con ID ${datos.busId} no existe o no pertenece al tenant ${tenantId}`,
+      );
+    }
+
+    // Validar conductor si se proporciona
+    if (datos.conductorId) {
+      const conductor = await this.prisma.usuarioTenant.findFirst({
+        where: {
+          id: datos.conductorId,
+          tenantId,
+          rol: 'CONDUCTOR',
+          activo: true,
+        },
+      });
+
+      if (!conductor) {
+        throw new NotFoundException(
+          `El conductor con ID ${datos.conductorId} no existe o no pertenece al tenant ${tenantId}`,
+        );
+      }
+    }
+
+    // Validar ayudante si se proporciona
+    if (datos.ayudanteId) {
+      const ayudante = await this.prisma.usuarioTenant.findFirst({
+        where: {
+          id: datos.ayudanteId,
+          tenantId,
+          rol: 'AYUDANTE',
+          activo: true,
+        },
+      });
+
+      if (!ayudante) {
+        throw new NotFoundException(
+          `El ayudante con ID ${datos.ayudanteId} no existe o no pertenece al tenant ${tenantId}`,
+        );
+      }
+    }
+
+    // Verificar que no exista un viaje duplicado
+    const viajeExistente = await this.prisma.viaje.findFirst({
+      where: {
+        fecha: new Date(datos.fecha),
+        horarioRutaId: datos.horarioRutaId,
+        busId: datos.busId,
+      },
+    });
+
+    if (viajeExistente) {
+      throw new ConflictException(
+        'Ya existe un viaje programado para esta ruta, fecha, horario y bus',
+      );
+    }
+
+    return await (tx || this.prisma).viaje.create({
+      data: {
+        tenantId,
+        horarioRutaId: datos.horarioRutaId,
+        busId: datos.busId,
+        conductorId: datos.conductorId,
+        ayudanteId: datos.ayudanteId,
+        fecha: new Date(datos.fecha),
+        estado: datos.estado ?? 'PROGRAMADO',
+        observaciones: datos.observaciones,
+        capacidadTotal: bus.totalAsientos,
+        asientosOcupados: 0,
+        generacion: datos.generacion ?? 'MANUAL',
+      },
+      select: VIAJE_SELECT_WITH_RELATIONS,
+    });
+  }
+
+  async actualizarViaje(
+    id: number,
+    datos: UpdateViajeDto,
+    tenantId: number,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const viaje = await this.obtenerViaje({ id, tenantId });
+
+    if (
+      viaje.estado === EstadoViaje.EN_RUTA ||
+      viaje.estado === EstadoViaje.COMPLETADO
+    ) {
+      throw new BadRequestException(
+        'No se puede actualizar un viaje en ruta o completado',
+      );
+    }
+
+    const datosActualizacion: Prisma.ViajeUncheckedUpdateInput = {};
+
+    if (datos.busId) {
+      const bus = await this.prisma.bus.findUnique({
+        where: { id: datos.busId, tenantId },
+      });
+      datosActualizacion.capacidadTotal = bus.totalAsientos;
+
+      if (!bus) {
+        throw new NotFoundException(
+          `El bus con ID ${datos.busId} no existe o no pertenece al tenant ${tenantId}`,
+        );
+      }
+    }
+
+    if (datos.conductorId) {
+      const conductor = await this.prisma.usuarioTenant.findFirst({
+        where: {
+          id: datos.conductorId,
+          tenantId,
+          rol: RolUsuario.CONDUCTOR,
+          activo: true,
+        },
+      });
+
+      if (!conductor) {
+        throw new NotFoundException(
+          `El conductor con ID ${datos.conductorId} no existe o no pertenece al tenant ${tenantId}`,
+        );
+      }
+    }
+
+    if (datos.ayudanteId) {
+      const ayudante = await this.prisma.usuarioTenant.findFirst({
+        where: {
+          id: datos.ayudanteId,
+          tenantId,
+          rol: RolUsuario.AYUDANTE,
+          activo: true,
+        },
+      });
+
+      if (!ayudante) {
+        throw new NotFoundException(
+          `El ayudante con ID ${datos.ayudanteId} no existe o no pertenece al tenant ${tenantId}`,
+        );
+      }
+    }
+
+    if (datos.horarioRutaId !== undefined)
+      datosActualizacion.horarioRutaId = datos.horarioRutaId;
+    if (datos.busId !== undefined) datosActualizacion.busId = datos.busId;
+    if (datos.conductorId !== undefined)
+      datosActualizacion.conductorId = datos.conductorId;
+    if (datos.ayudanteId !== undefined)
+      datosActualizacion.ayudanteId = datos.ayudanteId;
+    if (datos.fecha !== undefined)
+      datosActualizacion.fecha = new Date(datos.fecha);
+    if (datos.estado !== undefined) datosActualizacion.estado = datos.estado;
+    if (datos.observaciones !== undefined)
+      datosActualizacion.observaciones = datos.observaciones;
+    if (datos.generacion !== undefined)
+      datosActualizacion.generacion = datos.generacion;
+
+    return await (tx || this.prisma).viaje.update({
+      where: { id },
+      data: datosActualizacion,
+      select: VIAJE_SELECT_WITH_RELATIONS,
+    });
+  }
+
+  async cambiarEstadoViaje(
+    id: number,
+    nuevoEstado: EstadoViaje,
+    tenantId: number,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const viaje = await this.obtenerViaje({ id, tenantId });
+
+    if (viaje.estado === EstadoViaje.COMPLETADO) {
+      throw new BadRequestException(
+        'No se puede cambiar el estado de un viaje completado',
+      );
+    }
+
+    if (
+      nuevoEstado === EstadoViaje.PROGRAMADO &&
+      viaje.estado === EstadoViaje.EN_RUTA
+    ) {
+      throw new BadRequestException(
+        'No se puede programar un viaje que ya está en ruta',
+      );
+    }
+
+    if (
+      nuevoEstado === EstadoViaje.COMPLETADO &&
+      viaje.estado !== EstadoViaje.EN_RUTA
+    ) {
+      throw new BadRequestException(
+        'No se puede completar un viaje que no está en ruta',
+      );
+    }
+
+    if (
+      nuevoEstado === EstadoViaje.CANCELADO &&
+      viaje.estado === EstadoViaje.EN_RUTA
+    ) {
+      throw new BadRequestException(
+        'No se puede cancelar un viaje que está en ruta',
+      );
+    }
+
+    if (
+      nuevoEstado === EstadoViaje.RETRASADO &&
+      viaje.estado === EstadoViaje.EN_RUTA
+    ) {
+      throw new BadRequestException(
+        'No se puede retrasar un viaje que está en ruta',
+      );
+    }
+
+    let horaSalidaReal: Date | null = null;
+    if (nuevoEstado === EstadoViaje.EN_RUTA) {
+      horaSalidaReal = new Date();
+    }
+
+    return await (tx || this.prisma).viaje.update({
+      where: { id },
+      data: { estado: nuevoEstado, horaSalidaReal },
+      select: VIAJE_SELECT_WITH_RELATIONS,
+    });
+  }
+
+  async eliminarViaje(
+    id: number,
+    tenantId: number,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const viaje = await this.obtenerViaje({ id, tenantId });
+
+    if (
+      viaje.estado === EstadoViaje.EN_RUTA ||
+      viaje.estado === EstadoViaje.COMPLETADO
+    ) {
+      throw new BadRequestException(
+        'No se puede eliminar un viaje en ruta o completado',
+      );
+    }
+
+    // Verificar si hay boletos asociados
+    const boletosAsociados = await this.prisma.boleto.count({
+      where: { viajeId: id },
+    });
+
+    if (boletosAsociados > 0) {
+      throw new ConflictException(
+        `No se puede eliminar el viaje porque tiene ${boletosAsociados} boleto(s) asociado(s)`,
+      );
+    }
+
+    // Verificar si hay ventas asociadas
+    const ventasAsociadas = await this.prisma.venta.count({
+      where: { viajeId: id },
+    });
+
+    if (ventasAsociadas > 0) {
+      throw new ConflictException(
+        `No se puede eliminar el viaje porque tiene ${ventasAsociadas} venta(s) asociada(s)`,
+      );
+    }
+
+    return await (tx || this.prisma).viaje.delete({
+      where: { id },
+      select: VIAJE_SELECT_WITH_RELATIONS,
+    });
+  }
+
+  async obtenerViajesDisponibles(
+    horarioRutaId: number,
+    fecha: string,
+    tenantId?: number,
+  ) {
+    const filtro: Prisma.ViajeWhereInput = {
+      horarioRutaId,
+      fecha: new Date(fecha),
+      estado: {
+        in: [EstadoViaje.PROGRAMADO, EstadoViaje.RETRASADO],
+      },
+    };
+
+    if (tenantId) {
+      filtro.tenantId = tenantId;
+    }
+
+    return await this.prisma.viaje.findMany({
+      where: filtro,
+      orderBy: [{ horaSalidaReal: 'asc' }],
+      select: {
+        ...VIAJE_SELECT_WITH_RELATIONS,
+        _count: {
+          select: {
+            boletos: true,
+          },
+        },
+      },
+    });
+  }
+}


### PR DESCRIPTION
This pull request includes extensive changes to the Prisma schema, migrations, and seed scripts to refactor the database structure and improve seed initialization. Key changes include removing the `rutaId` column from the `Viaje` model, updating related constraints and indices, and modularizing the seed scripts for better organization and scalability.

### Database Schema Refactoring

* Removed the `rutaId` column from the `Viaje` model, along with its relation to the `Ruta` model. Updated the unique constraint to exclude `rutaId` and replaced it with `[horarioRutaId, fecha, busId]`. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL380-R384) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL395) [[3]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL405-R404)
* Made the `horaSalidaReal` column in the `Viaje` model optional by dropping the `NOT NULL` constraint.

### Migration Updates

* Dropped the foreign key constraint and indices related to `rutaId` in the `viajes` table. Added new indices and a unique constraint for `[horarioRutaId, fecha, busId]`.

### Seed Script Modularization

* Refactored `prisma/seed.ts` to modularize seeding logic into separate files for cities, buses, routes, and other entities. Added a database cleaning function for proper initialization.
* Created `seed-buses.ts` to dynamically generate buses, their floors, seats, and characteristics based on tenants and bus models.
* Created `seed-cuidades.ts` to seed cities using the data from `data/ciudades.ts`.
* Created `seed-modelo-buses-tipos-de-asientos.ts` to seed bus models, seat types, and seating templates for tenants.

### Type Updates

* Changed the type of `ciudades` in `data/ciudades.ts` to `Prisma.CiudadCreateInput[]` for compatibility with Prisma's `createMany` method.