### PR TITLE
Fix/agregar tipo de rutas buses cu 86a9uhdqe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs-modules/mailer": "^2.0.2",
+        "@nestjs/cli": "^11.0.7",
         "@nestjs/common": "^11.1.0",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.0",

--- a/prisma/migrations/20250629014608_add_tipo_ruta_bus/migration.sql
+++ b/prisma/migrations/20250629014608_add_tipo_ruta_bus/migration.sql
@@ -1,0 +1,33 @@
+/*
+  Warnings:
+
+  - Added the required column `tipoRutaBusId` to the `buses` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `tipoRutaBusId` to the `rutas` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "buses" ADD COLUMN     "tipoRutaBusId" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "rutas" ADD COLUMN     "tipoRutaBusId" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "tipos_ruta_buse" (
+    "id" SERIAL NOT NULL,
+    "tenantId" INTEGER NOT NULL,
+    "nombre" TEXT NOT NULL,
+
+    CONSTRAINT "tipos_ruta_buse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "tipos_ruta_buse_tenantId_idx" ON "tipos_ruta_buse"("tenantId");
+
+-- AddForeignKey
+ALTER TABLE "tipos_ruta_buse" ADD CONSTRAINT "tipos_ruta_buse_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "buses" ADD CONSTRAINT "buses_tipoRutaBusId_fkey" FOREIGN KEY ("tipoRutaBusId") REFERENCES "tipos_ruta_buse"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "rutas" ADD CONSTRAINT "rutas_tipoRutaBusId_fkey" FOREIGN KEY ("tipoRutaBusId") REFERENCES "tipos_ruta_buse"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250629021519_add_tipo_ruta_bus/migration.sql
+++ b/prisma/migrations/20250629021519_add_tipo_ruta_bus/migration.sql
@@ -1,0 +1,38 @@
+/*
+  Warnings:
+
+  - You are about to drop the `tipos_ruta_buse` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "buses" DROP CONSTRAINT "buses_tipoRutaBusId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "rutas" DROP CONSTRAINT "rutas_tipoRutaBusId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "tipos_ruta_buse" DROP CONSTRAINT "tipos_ruta_buse_tenantId_fkey";
+
+-- DropTable
+DROP TABLE "tipos_ruta_buse";
+
+-- CreateTable
+CREATE TABLE "tipos_ruta_bus" (
+    "id" SERIAL NOT NULL,
+    "tenantId" INTEGER NOT NULL,
+    "nombre" TEXT NOT NULL,
+
+    CONSTRAINT "tipos_ruta_bus_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "tipos_ruta_bus_tenantId_idx" ON "tipos_ruta_bus"("tenantId");
+
+-- AddForeignKey
+ALTER TABLE "tipos_ruta_bus" ADD CONSTRAINT "tipos_ruta_bus_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "buses" ADD CONSTRAINT "buses_tipoRutaBusId_fkey" FOREIGN KEY ("tipoRutaBusId") REFERENCES "tipos_ruta_bus"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "rutas" ADD CONSTRAINT "rutas_tipoRutaBusId_fkey" FOREIGN KEY ("tipoRutaBusId") REFERENCES "tipos_ruta_bus"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -224,7 +224,7 @@ model TipoRutaBus {
   Ruta     Ruta[]
 
   @@index([tenantId])
-  @@map("tipos_ruta_buse")
+  @@map("tipos_ruta_bus")
 }
 
 model Bus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Tenant {
   configuraciones         Configuracion[]
   notificaciones          Notificacion[]
   metodosPago             MetodoPago[]
+  TipoRutaBus             TipoRutaBus[]
 
   @@map("tenants")
 }
@@ -141,7 +142,7 @@ model Ciudad {
   longitud  Decimal? @db.Decimal(10, 6)
   activo    Boolean  @default(true)
 
-  paradas      ParadaRuta[]
+  paradas ParadaRuta[]
 
   @@map("ciudades")
 }
@@ -214,10 +215,23 @@ model UbicacionAsientoPlantilla {
   @@map("ubicaciones_asiento_plantilla")
 }
 
+model TipoRutaBus {
+  id       Int    @id @default(autoincrement())
+  tenantId Int
+  nombre   String
+  tenant   Tenant @relation(fields: [tenantId], references: [id])
+  Bus      Bus[]
+  Ruta     Ruta[]
+
+  @@index([tenantId])
+  @@map("tipos_ruta_buse")
+}
+
 model Bus {
   id              Int       @id @default(autoincrement())
   tenantId        Int
   modeloBusId     Int
+  tipoRutaBusId   Int
   numero          Int
   placa           String
   anioFabricacion Int?
@@ -230,6 +244,7 @@ model Bus {
   // Relaciones
   tenant          Tenant              @relation(fields: [tenantId], references: [id])
   modeloBus       ModeloBus           @relation(fields: [modeloBusId], references: [id])
+  tipoRutaBus     TipoRutaBus         @relation(fields: [tipoRutaBusId], references: [id])
   pisos           PisoBus[]
   viajes          Viaje[] // NUEVO: reemplaza hojasTrabajo
   caracteristicas CaracteristicaBus[]
@@ -311,18 +326,20 @@ model Asiento {
 // MODELOS SIMPLIFICADOS PARA RUTAS Y VIAJES
 
 model Ruta {
-  id              Int      @id @default(autoincrement())
-  tenantId        Int
-  nombre          String
-  resolucionId    Int
-  descripcion     String?
-  activo          Boolean  @default(true)
+  id            Int     @id @default(autoincrement())
+  tenantId      Int
+  tipoRutaBusId Int
+  nombre        String
+  resolucionId  Int
+  descripcion   String?
+  activo        Boolean @default(true)
 
   // Relaciones
-  tenant        Tenant        @relation(fields: [tenantId], references: [id])
-  resolucion    ResolucionANT @relation(fields: [resolucionId], references: [id])
-  paradas       ParadaRuta[] // Paradas intermedias ordenadas
-  horarios      HorarioRuta[] // Horarios de salida de la ruta
+  tenant      Tenant        @relation(fields: [tenantId], references: [id])
+  tipoRutaBus TipoRutaBus   @relation(fields: [tipoRutaBusId], references: [id])
+  resolucion  ResolucionANT @relation(fields: [resolucionId], references: [id])
+  paradas     ParadaRuta[] // Paradas intermedias ordenadas
+  horarios    HorarioRuta[] // Horarios de salida de la ruta
 
   @@unique([tenantId, nombre])
   @@index([tenantId]) // Índice para búsquedas eficientes
@@ -331,13 +348,13 @@ model Ruta {
 
 // NUEVO: Paradas intermedias simplificadas
 model ParadaRuta {
-  id                  Int      @id @default(autoincrement())
-  rutaId              Int
-  ciudadId            Int
-  orden               Int // Orden en la ruta (0 = origen, último = destino)
-  distanciaAcumulada  Decimal? @db.Decimal(10, 2) // Desde el origen
-  tiempoAcumulado     Int // Minutos desde el origen
-  precioAcumulado     Decimal  @db.Decimal(10, 2) // Precio desde el origen
+  id                 Int      @id @default(autoincrement())
+  rutaId             Int
+  ciudadId           Int
+  orden              Int // Orden en la ruta (0 = origen, último = destino)
+  distanciaAcumulada Decimal? @db.Decimal(10, 2) // Desde el origen
+  tiempoAcumulado    Int // Minutos desde el origen
+  precioAcumulado    Decimal  @db.Decimal(10, 2) // Precio desde el origen
 
   // Relaciones
   ruta   Ruta   @relation(fields: [rutaId], references: [id], onDelete: Cascade)
@@ -359,11 +376,11 @@ model ParadaRuta {
 
 // NUEVO: Horarios simplificados
 model HorarioRuta {
-  id         Int       @id @default(autoincrement())
+  id         Int     @id @default(autoincrement())
   rutaId     Int
   horaSalida String // "12:00"
   diasSemana String // "1111111" o "1111100" etc
-  activo     Boolean   @default(true)
+  activo     Boolean @default(true)
 
   // Relaciones
   ruta   Ruta    @relation(fields: [rutaId], references: [id], onDelete: Cascade)
@@ -465,17 +482,17 @@ model MetodoPago {
 }
 
 model Venta {
-  id                Int         @id @default(autoincrement())
+  id                Int        @id @default(autoincrement())
   tenantId          Int
-  viajeId           Int 
+  viajeId           Int
   usuarioId         Int
   oficinistaId      Int?
-  fechaVenta        DateTime    @default(now())
+  fechaVenta        DateTime   @default(now())
   metodoPagoId      Int
-  totalSinDescuento Decimal     @db.Decimal(10, 2)
-  totalDescuentos   Decimal     @default(0) @db.Decimal(10, 2)
-  totalFinal        Decimal     @db.Decimal(10, 2)
-  estadoPago        EstadoPago  @default(PENDIENTE)
+  totalSinDescuento Decimal    @db.Decimal(10, 2)
+  totalDescuentos   Decimal    @default(0) @db.Decimal(10, 2)
+  totalFinal        Decimal    @db.Decimal(10, 2)
+  estadoPago        EstadoPago @default(PENDIENTE)
 
   // Relaciones
   tenant     Tenant     @relation(fields: [tenantId], references: [id])
@@ -530,12 +547,12 @@ model Boleto {
 }
 
 model RegistroAbordaje {
-  id              Int            @id @default(autoincrement())
-  boletoId        Int
-  usuarioId       Int
-  fechaHora       DateTime       @default(now())
-  estadoAbordaje  EstadoAbordaje @default(PENDIENTE)
-  observaciones   String?
+  id             Int            @id @default(autoincrement())
+  boletoId       Int
+  usuarioId      Int
+  fechaHora      DateTime       @default(now())
+  estadoAbordaje EstadoAbordaje @default(PENDIENTE)
+  observaciones  String?
 
   // Relaciones
   boleto      Boleto  @relation(fields: [boletoId], references: [id])
@@ -624,8 +641,6 @@ enum EstadoAsiento {
   RESERVADO
 }
 
-
-
 enum TipoDescuento {
   MENOR_EDAD
   TERCERA_EDAD
@@ -653,8 +668,6 @@ enum EstadoPago {
   RECHAZADO
 }
 
-
-
 enum TipoDescuentoCliente {
   NINGUNO
   MENOR_EDAD
@@ -669,7 +682,6 @@ enum EstadoBoleto {
   NO_SHOW
   CANCELADO
 }
-
 
 enum TipoConfiguracion {
   TEXTO

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,6 +6,7 @@ import { seedUsuarios } from './seeds/seed-usuarios-personal';
 import { seedBuses } from './seeds/seed-buses';
 import { seedCiudades } from './seeds/seed-cuidades';
 import { seedRutas } from './seeds/seed-ruta-horario';
+import { seedTiposRutaBus } from './seeds/seed-tipos-ruta-bus';
 
 const prisma = new PrismaClient();
 
@@ -23,11 +24,14 @@ async function main() {
   console.log('🚌 Creando modelos de buses...');
   const { modelosBus, plantillasPiso, tiposAsiento } = await seedModelosBuses(prisma, tenants);
 
+  console.log('🛣️ Creando tipos de ruta de bus...');
+  const tiposRutaBus = await seedTiposRutaBus(prisma, tenants);
+
   console.log('🚐 Creando buses...');
-  await seedBuses(prisma, tenants, modelosBus, plantillasPiso, tiposAsiento);
+  await seedBuses(prisma, tenants, modelosBus, plantillasPiso, tiposAsiento, tiposRutaBus);
 
   console.log('🛣️ Creando rutas...');
-  const rutas = await seedRutas(prisma, tenants);
+  const rutas = await seedRutas(prisma, tenants, tiposRutaBus);
 
   console.log('✅ Seed completado exitosamente!');
 }
@@ -50,6 +54,7 @@ async function cleanDatabase() {
   await prisma.ubicacionAsientoPlantilla.deleteMany();
   await prisma.plantillaPiso.deleteMany();
   await prisma.modeloBus.deleteMany();
+  await prisma.tipoRutaBus.deleteMany();
   await prisma.resolucionANT.deleteMany();
   await prisma.personalCooperativa.deleteMany();
   await prisma.usuarioTenant.deleteMany();

--- a/prisma/seeds/seed-buses.ts
+++ b/prisma/seeds/seed-buses.ts
@@ -1,7 +1,7 @@
 // prisma/seeds/buses.seed.ts
 import { PrismaClient, EstadoBus, EstadoAsiento } from '@prisma/client';
 
-export async function seedBuses(prisma: PrismaClient, tenants: any[], modelosBus: any[], plantillasPiso: any[], tiposAsiento: any[]) {
+export async function seedBuses(prisma: PrismaClient, tenants: any[], modelosBus: any[], plantillasPiso: any[], tiposAsiento: any[], tiposRutaBus: any[]) {
   const buses = [];
   const pisosBus = [];
 
@@ -9,13 +9,18 @@ export async function seedBuses(prisma: PrismaClient, tenants: any[], modelosBus
     const tenant = tenants[tenantIndex];
     const tenantPrefix = tenantIndex === 0 ? 'TPE' : tenantIndex === 1 ? 'TBA' : 'TRB';
     
-    // Obtener tipos de asiento para este tenant
+    // Obtener tipos de asiento y tipos de ruta para este tenant
     const tiposAsientoTenant = tiposAsiento.filter(ta => ta.tenantId === tenant.id);
+    const tiposRutaBusTenant = tiposRutaBus.filter(trb => trb.tenantId === tenant.id);
     
     for (let busIndex = 1; busIndex <= 12; busIndex++) {
       // Alternar entre diferentes modelos
       const modeloIndex = (busIndex - 1) % modelosBus.length;
       const modelo = modelosBus[modeloIndex];
+      
+      // Alternar entre tipos de ruta de bus
+      const tipoRutaBusIndex = busIndex % tiposRutaBusTenant.length;
+      const tipoRutaBus = tiposRutaBusTenant[tipoRutaBusIndex];
       
       // Calcular asientos según el modelo
       let totalAsientos;
@@ -33,6 +38,7 @@ export async function seedBuses(prisma: PrismaClient, tenants: any[], modelosBus
         data: {
           tenantId: tenant.id,
           modeloBusId: modelo.id,
+          tipoRutaBusId: tipoRutaBus.id,
           numero: (tenantIndex * 100) + 100 + busIndex,
           placa: `${tenantPrefix}-${String(1000 + busIndex).slice(1)}`,
           anioFabricacion: 2018 + (busIndex % 5),

--- a/prisma/seeds/seed-ruta-horario.ts
+++ b/prisma/seeds/seed-ruta-horario.ts
@@ -2,7 +2,7 @@
 import { PrismaClient } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 
-export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
+export async function seedRutas(prisma: PrismaClient, tenants: any[], tiposRutaBus: any[]) {
   // Crear resoluciones ANT
   const resolucionesANT = await Promise.all([
     prisma.resolucionANT.create({
@@ -48,6 +48,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Pelileo - Ambato - Quito',
       descripcion: 'Ruta interprovincial desde Pelileo hasta Quito con parada en Ambato',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Pelileo', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Ambato', orden: 1, distancia: 18.5, tiempo: 25, precio: 1.5 },
@@ -61,6 +62,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Pelileo - Riobamba',
       descripcion: 'Ruta intercantonal directa desde Pelileo hasta Riobamba',
+      tipoRuta: 'Intercantonal',
       paradas: [
         { ciudad: 'Pelileo', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Riobamba', orden: 1, distancia: 65.2, tiempo: 90, precio: 3.5 },
@@ -73,6 +75,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Pelileo - Latacunga - Quito',
       descripcion: 'Ruta alternativa hacia Quito vía Latacunga',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Pelileo', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Ambato', orden: 1, distancia: 18.5, tiempo: 25, precio: 1.5 },
@@ -86,6 +89,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Pelileo - Cuenca',
       descripcion: 'Ruta hacia el sur del país',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Pelileo', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Riobamba', orden: 1, distancia: 65.2, tiempo: 90, precio: 3.5 },
@@ -100,6 +104,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Ambato - Guaranda',
       descripcion: 'Ruta intercantonal hacia Bolívar',
+      tipoRuta: 'Intercantonal',
       paradas: [
         { ciudad: 'Ambato', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Guaranda', orden: 1, distancia: 62.4, tiempo: 95, precio: 3.8 },
@@ -115,6 +120,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Baños - Puyo - Tena',
       descripcion: 'Ruta turística amazónica desde Baños hasta Tena',
+      tipoRuta: 'Turístico',
       paradas: [
         { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Puyo', orden: 1, distancia: 61.4, tiempo: 75, precio: 2.75 },
@@ -128,6 +134,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Baños - Ambato - Latacunga',
       descripcion: 'Ruta interprovincial hacia el norte',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Ambato', orden: 1, distancia: 42.3, tiempo: 55, precio: 2.25 },
@@ -141,6 +148,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Baños - Riobamba - Alausí',
       descripcion: 'Ruta turística hacia la Nariz del Diablo',
+      tipoRuta: 'Turístico',
       paradas: [
         { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Riobamba', orden: 1, distancia: 85.7, tiempo: 110, precio: 4.2 },
@@ -154,6 +162,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Baños - Quito',
       descripcion: 'Ruta directa hacia la capital',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Ambato', orden: 1, distancia: 42.3, tiempo: 55, precio: 2.25 },
@@ -168,6 +177,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Baños - Shell',
       descripcion: 'Ruta corta hacia Shell Mera',
+      tipoRuta: 'Turístico',
       paradas: [
         { ciudad: 'Baños', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Shell', orden: 1, distancia: 18.2, tiempo: 25, precio: 1.25 },
@@ -184,6 +194,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Riobamba - Guayaquil',
       descripcion: 'Ruta interprovincial hacia la costa',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Alausí', orden: 1, distancia: 56.6, tiempo: 75, precio: 2.8 },
@@ -199,6 +210,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Riobamba - Quito',
       descripcion: 'Ruta directa hacia la capital',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Ambato', orden: 1, distancia: 47.2, tiempo: 65, precio: 2.4 },
@@ -213,6 +225,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Riobamba - Cuenca',
       descripcion: 'Ruta hacia la región austral',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Azogues', orden: 1, distancia: 90.1, tiempo: 120, precio: 4.5 },
@@ -226,6 +239,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Riobamba - Macas',
       descripcion: 'Ruta hacia la amazonia sur',
+      tipoRuta: 'Interprovincial',
       paradas: [
         { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Macas', orden: 1, distancia: 142.6, tiempo: 210, precio: 7.1 },
@@ -237,6 +251,7 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
     {
       nombre: 'Riobamba - Guaranda - Babahoyo',
       descripcion: 'Ruta hacia Los Ríos vía Guaranda',
+      tipoRuta: 'Ejecutivo',
       paradas: [
         { ciudad: 'Riobamba', orden: 0, distancia: 0, tiempo: 0, precio: 0 },
         { ciudad: 'Guaranda', orden: 1, distancia: 68.3, tiempo: 85, precio: 3.4 },
@@ -255,12 +270,17 @@ export async function seedRutas(prisma: PrismaClient, tenants: any[]) {
   for (let tenantIndex = 0; tenantIndex < tenants.length; tenantIndex++) {
     const tenant = tenants[tenantIndex];
     const rutasTenant = allRutas[tenantIndex];
+    const tiposRutaBusTenant = tiposRutaBus.filter(trb => trb.tenantId === tenant.id);
     
     for (const rutaData of rutasTenant) {
+      // Encontrar el tipo de ruta correspondiente
+      const tipoRutaBus = tiposRutaBusTenant.find(trb => trb.nombre === rutaData.tipoRuta);
+      
       // Crear la ruta
       const ruta = await prisma.ruta.create({
         data: {
           tenantId: tenant.id,
+          tipoRutaBusId: tipoRutaBus.id,
           nombre: rutaData.nombre,
           resolucionId: resolucionesANT[tenantIndex % resolucionesANT.length].id,
           descripcion: rutaData.descripcion,

--- a/prisma/seeds/seed-tipos-ruta-bus.ts
+++ b/prisma/seeds/seed-tipos-ruta-bus.ts
@@ -1,0 +1,61 @@
+// prisma/seeds/tipos-ruta-bus.seed.ts
+import { PrismaClient } from '@prisma/client';
+
+export async function seedTiposRutaBus(prisma: PrismaClient, tenants: any[]) {
+  const tiposRutaBus = [];
+
+  for (let tenantIndex = 0; tenantIndex < tenants.length; tenantIndex++) {
+    const tenant = tenants[tenantIndex];
+    
+    // Crear tipos de ruta específicos para cada cooperativa
+    if (tenantIndex === 0) { // Flota Pelileo
+      tiposRutaBus.push(
+        await prisma.tipoRutaBus.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Interprovincial',
+          },
+        }),
+        await prisma.tipoRutaBus.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Intercantonal',
+          },
+        })
+      );
+    } else if (tenantIndex === 1) { // Transportes Baños
+      tiposRutaBus.push(
+        await prisma.tipoRutaBus.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Turístico',
+          },
+        }),
+        await prisma.tipoRutaBus.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Interprovincial',
+          },
+        })
+      );
+    } else { // Expreso Riobamba
+      tiposRutaBus.push(
+        await prisma.tipoRutaBus.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Interprovincial',
+          },
+        }),
+        await prisma.tipoRutaBus.create({
+          data: {
+            tenantId: tenant.id,
+            nombre: 'Ejecutivo',
+          },
+        })
+      );
+    }
+  }
+
+  console.log(`✅ Creados ${tiposRutaBus.length} tipos de ruta de bus`);
+  return tiposRutaBus;
+} 

--- a/prisma/seeds/seed-viajes.ts
+++ b/prisma/seeds/seed-viajes.ts
@@ -1,0 +1,155 @@
+import { PrismaClient, EstadoViaje, TipoGeneracion } from '@prisma/client';
+
+export async function seedViajes(prisma: PrismaClient, tenants: any[]) {
+  const viajes = [];
+
+  // Generar viajes para los próximos 30 días
+  const fechaInicio = new Date();
+  const fechaFin = new Date();
+  fechaFin.setDate(fechaFin.getDate() + 30);
+
+  // Obtener todos los horarios de rutas activos
+  const horariosRutas = await prisma.horarioRuta.findMany({
+    where: { activo: true },
+    include: {
+      ruta: {
+        include: {
+          tenant: true,
+          tipoRutaBus: true,
+        },
+      },
+    },
+  });
+
+  // Obtener buses disponibles por tenant
+  const busesPorTenant = await prisma.bus.findMany({
+    where: { estado: 'ACTIVO' },
+    include: {
+      tenant: true,
+      tipoRutaBus: true,
+    },
+  });
+
+  // Obtener conductores y ayudantes disponibles
+  const personalDisponible = await prisma.usuarioTenant.findMany({
+    where: {
+      activo: true,
+      rol: { in: ['CONDUCTOR', 'AYUDANTE'] },
+    },
+    include: {
+      tenant: true,
+    },
+  });
+
+  // Agrupar buses por tenant y tipo de ruta
+  const busesPorTenantYTipo = new Map<string, any[]>();
+  for (const bus of busesPorTenant) {
+    const key = `${bus.tenantId}-${bus.tipoRutaBusId}`;
+    if (!busesPorTenantYTipo.has(key)) {
+      busesPorTenantYTipo.set(key, []);
+    }
+    busesPorTenantYTipo.get(key)!.push(bus);
+  }
+
+  // Agrupar horarios por tenant y tipo de ruta
+  const horariosPorTenantYTipo = new Map<string, any[]>();
+  for (const horario of horariosRutas) {
+    const key = `${horario.ruta.tenantId}-${horario.ruta.tipoRutaBusId}`;
+    if (!horariosPorTenantYTipo.has(key)) {
+      horariosPorTenantYTipo.set(key, []);
+    }
+    horariosPorTenantYTipo.get(key)!.push(horario);
+  }
+
+  for (const [key, horariosDelTipo] of horariosPorTenantYTipo.entries()) {
+    const [tenantId, tipoRutaBusId] = key.split('-').map(Number);
+    const busesDelTipo = busesPorTenantYTipo.get(key) || [];
+
+    if (busesDelTipo.length === 0) {
+      console.log(`⚠️ No hay buses disponibles para el tenant ${tenantId} y tipo de ruta ${tipoRutaBusId}`);
+      continue;
+    }
+
+    // Obtener personal del tenant
+    const personalTenant = personalDisponible.filter(p => p.tenantId === tenantId);
+    const conductores = personalTenant.filter(p => p.rol === 'CONDUCTOR');
+    const ayudantes = personalTenant.filter(p => p.rol === 'AYUDANTE');
+
+    // Generar viajes para cada horario del tipo
+    for (const horarioRuta of horariosDelTipo) {
+      // Generar viajes para cada día en el rango
+      const fechaActual = new Date(fechaInicio);
+      while (fechaActual <= fechaFin) {
+        // Verificar si el horario opera en este día de la semana
+        const diaSemana = fechaActual.getDay(); // 0 = domingo, 1 = lunes, etc.
+        const diasSemana = horarioRuta.diasSemana;
+        
+        // Convertir el día de la semana a la posición en el string (domingo = 0, lunes = 1, etc.)
+        const posicionDia = diaSemana === 0 ? 6 : diaSemana - 1; // Ajustar para que domingo sea posición 6
+        
+        if (diasSemana[posicionDia] === '1') {
+          // Seleccionar bus aleatoriamente del mismo tipo
+          const busIndex = Math.floor(Math.random() * busesDelTipo.length);
+          const bus = busesDelTipo[busIndex];
+
+          // Seleccionar conductor y ayudante aleatoriamente
+          const conductor = conductores.length > 0 ? conductores[Math.floor(Math.random() * conductores.length)] : null;
+          const ayudante = ayudantes.length > 0 ? ayudantes[Math.floor(Math.random() * ayudantes.length)] : null;
+
+          // Crear hora de salida real combinando fecha y hora
+          const [hora, minuto] = horarioRuta.horaSalida.split(':');
+          const horaSalidaReal = new Date(fechaActual);
+          horaSalidaReal.setHours(parseInt(hora), parseInt(minuto), 0, 0);
+
+          // Determinar estado del viaje basado en la fecha
+          let estado: EstadoViaje;
+          const hoy = new Date();
+          const fechaViaje = new Date(fechaActual);
+          
+          if (fechaViaje < hoy) {
+            estado = EstadoViaje.COMPLETADO;
+          } else if (fechaViaje.getDate() === hoy.getDate() && fechaViaje.getMonth() === hoy.getMonth() && fechaViaje.getFullYear() === hoy.getFullYear()) {
+            estado = EstadoViaje.EN_RUTA;
+          } else {
+            estado = EstadoViaje.PROGRAMADO;
+          }
+
+          const viaje = await prisma.viaje.create({
+            data: {
+              tenantId: Number(tenantId),
+              horarioRutaId: horarioRuta.id,
+              busId: bus.id,
+              conductorId: conductor?.id || null,
+              ayudanteId: ayudante?.id || null,
+              fecha: fechaActual,
+              horaSalidaReal,
+              estado,
+              capacidadTotal: bus.totalAsientos,
+              asientosOcupados: 0,
+              generacion: TipoGeneracion.AUTOMATICA,
+            },
+          });
+
+          viajes.push(viaje);
+        }
+
+        // Avanzar al siguiente día
+        fechaActual.setDate(fechaActual.getDate() + 1);
+      }
+    }
+  }
+
+  console.log(`✅ Creados ${viajes.length} viajes para los próximos 30 días`);
+  
+  // Mostrar estadísticas por tenant
+  for (const tenant of tenants) {
+    const viajesTenant = viajes.filter(v => v.tenantId === tenant.id);
+    const programados = viajesTenant.filter(v => v.estado === EstadoViaje.PROGRAMADO).length;
+    const enRuta = viajesTenant.filter(v => v.estado === EstadoViaje.EN_RUTA).length;
+    const completados = viajesTenant.filter(v => v.estado === EstadoViaje.COMPLETADO).length;
+    
+    console.log(`   - ${tenant.nombre}: ${viajesTenant.length} viajes (${programados} programados, ${enRuta} en ruta, ${completados} completados)`);
+  }
+
+  return viajes;
+} 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,7 @@ import { VentasModule } from './modules/ventas/ventas.module';
 import { MetodosPagoModule } from './modules/metodos-pago/metodos-pago.module';
 import { ConfiguracionDescuentosModule } from './modules/configuracion-descuentos/configuracion-descuentos.module';
 import { EmailModule } from './modules/email/email.module';
+import { TiposRutaBusModule } from './modules/tipos-ruta-bus/tipos-ruta-bus.module';
 
 @Module({
   imports: [
@@ -58,6 +59,7 @@ import { EmailModule } from './modules/email/email.module';
     MetodosPagoModule,
     ConfiguracionDescuentosModule,
     EmailModule,
+    TiposRutaBusModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/buses/buses.service.ts
+++ b/src/modules/buses/buses.service.ts
@@ -210,6 +210,21 @@ export class BusesService {
   ) {
     console.log('tenantId', tenantId);
     console.log('datos', datos);
+    
+    // Validar que el tipo de ruta de bus pertenezca al tenant
+    const tipoRutaBus = await this.prisma.tipoRutaBus.findFirst({
+      where: {
+        id: datos.tipoRutaBusId,
+        tenantId,
+      },
+    });
+
+    if (!tipoRutaBus) {
+      throw new NotFoundException(
+        `El tipo de ruta de bus con ID ${datos.tipoRutaBusId} no existe o no pertenece al tenant ${tenantId}`,
+      );
+    }
+
     const existenteNumero = await this.prisma.bus.findUnique({
       where: {
         tenantId_numero: {
@@ -256,6 +271,22 @@ export class BusesService {
     tx?: Prisma.TransactionClient,
   ) {
     await this.obtenerBus({ id });
+
+    // Validar que el tipo de ruta de bus pertenezca al tenant si se está actualizando
+    if (datos.tipoRutaBusId) {
+      const tipoRutaBus = await this.prisma.tipoRutaBus.findFirst({
+        where: {
+          id: datos.tipoRutaBusId,
+          tenantId,
+        },
+      });
+
+      if (!tipoRutaBus) {
+        throw new NotFoundException(
+          `El tipo de ruta de bus con ID ${datos.tipoRutaBusId} no existe o no pertenece al tenant ${tenantId}`,
+        );
+      }
+    }
 
     if (datos.numero) {
       const existenteNumero = await this.prisma.bus.findFirst({

--- a/src/modules/buses/constants/bus-select.ts
+++ b/src/modules/buses/constants/bus-select.ts
@@ -4,6 +4,7 @@ export const BUS_SELECT: Prisma.BusSelect = {
   id: true,
   tenantId: true,
   modeloBusId: true,
+  tipoRutaBusId: true,
   numero: true,
   placa: true,
   anioFabricacion: true,
@@ -32,6 +33,12 @@ export const BUS_SELECT_WITH_RELATIONS: Prisma.BusSelect = {
       numeroPisos: true,
     },
   },
+  tipoRutaBus: {
+    select: {
+      id: true,
+      nombre: true,
+    },
+  },
 };
 
 export type BusWithPisosAndAsientos = Prisma.BusGetPayload<{
@@ -54,6 +61,12 @@ export const BUS_SELECT_WITH_PISOS_AND_ASIENTOS: Prisma.BusSelect = {
       tipoChasis: true,
       tipoCarroceria: true,
       numeroPisos: true,
+    },
+  },
+  tipoRutaBus: {
+    select: {
+      id: true,
+      nombre: true,
     },
   },
   pisos: {

--- a/src/modules/buses/dto/create-bus.dto.ts
+++ b/src/modules/buses/dto/create-bus.dto.ts
@@ -22,6 +22,14 @@ export class CreateBusDto {
   modeloBusId: number;
 
   @ApiProperty({
+    description: 'ID del tipo de ruta de bus',
+    example: 1,
+  })
+  @IsInt({ message: 'El ID del tipo de ruta de bus debe ser un número entero' })
+  @IsNotEmpty({ message: 'El ID del tipo de ruta de bus es requerido' })
+  tipoRutaBusId: number;
+
+  @ApiProperty({
     description: 'Número del bus (único por tenant)',
     example: 42,
   })

--- a/src/modules/buses/dto/filtro-bus.dto.ts
+++ b/src/modules/buses/dto/filtro-bus.dto.ts
@@ -56,6 +56,15 @@ export class FiltroBusDto {
   modeloBusId?: number;
 
   @ApiProperty({
+    description: 'Filtrar por ID de tipo de ruta de bus',
+    required: false,
+  })
+  @IsInt({ message: 'El ID del tipo de ruta de bus debe ser un número entero' })
+  @IsOptional()
+  @Transform(({ value }) => (value ? parseInt(value) : undefined))
+  tipoRutaBusId?: number;
+
+  @ApiProperty({
     description: 'Filtrar por estado',
     required: false,
     enum: EstadoBus,

--- a/src/modules/buses/utils/filtro-bus-build.ts
+++ b/src/modules/buses/utils/filtro-bus-build.ts
@@ -17,6 +17,7 @@ export const filtroBusBuild = (
     anioFabricacion,
     tipoCombustible,
     modeloBusId,
+    tipoRutaBusId,
     estado,
   } = filtro;
 
@@ -38,6 +39,10 @@ export const filtroBusBuild = (
 
   if (modeloBusId !== undefined) {
     where.modeloBusId = modeloBusId;
+  }
+
+  if (tipoRutaBusId !== undefined) {
+    where.tipoRutaBusId = tipoRutaBusId;
   }
 
   if (estado) {

--- a/src/modules/rutas/constants/ruta-select.ts
+++ b/src/modules/rutas/constants/ruta-select.ts
@@ -4,6 +4,7 @@ import { RESOLUCION_ANT_SELECT } from 'src/modules/resoluciones-ant/constants/re
 export const RUTA_SELECT: Prisma.RutaSelect = {
   id: true,
   tenantId: true,
+  tipoRutaBusId: true,
   nombre: true,
   resolucionId: true,
   descripcion: true,
@@ -13,6 +14,12 @@ export const RUTA_SELECT: Prisma.RutaSelect = {
 export const RUTA_SELECT_WITH_RELATIONS: Prisma.RutaSelect = {
   ...RUTA_SELECT,
   tenant: {
+    select: {
+      id: true,
+      nombre: true,
+    },
+  },
+  tipoRutaBus: {
     select: {
       id: true,
       nombre: true,

--- a/src/modules/rutas/dto/create-ruta.dto.ts
+++ b/src/modules/rutas/dto/create-ruta.dto.ts
@@ -17,6 +17,14 @@ export class CreateRutaDto {
   nombre: string;
 
   @ApiProperty({
+    description: 'ID del tipo de ruta de bus',
+    example: 1,
+  })
+  @IsInt({ message: 'El ID del tipo de ruta de bus debe ser un número entero' })
+  @IsNotEmpty({ message: 'El ID del tipo de ruta de bus es requerido' })
+  tipoRutaBusId: number;
+
+  @ApiProperty({
     description: 'ID de la resolución ANT',
     example: 1,
   })

--- a/src/modules/rutas/dto/filtro-ruta.dto.ts
+++ b/src/modules/rutas/dto/filtro-ruta.dto.ts
@@ -17,6 +17,15 @@ export class FiltroRutaDto {
   nombre?: string;
 
   @ApiProperty({
+    description: 'Filtrar por ID de tipo de ruta de bus',
+    required: false,
+  })
+  @IsInt({ message: 'El ID del tipo de ruta de bus debe ser un número entero' })
+  @IsOptional()
+  @Transform(({ value }) => (value ? parseInt(value) : undefined))
+  tipoRutaBusId?: number;
+
+  @ApiProperty({
     description: 'Filtrar por ID de resolución ANT',
     required: false,
   })

--- a/src/modules/rutas/utils/filtro-ruta-build.ts
+++ b/src/modules/rutas/utils/filtro-ruta-build.ts
@@ -11,10 +11,14 @@ export const filtroRutaBuild = (
     where.tenantId = tenantId;
   }
 
-  const { nombre, resolucionId, activo } = filtro;
+  const { nombre, tipoRutaBusId, resolucionId, activo } = filtro;
 
   if (nombre) {
     where.nombre = { contains: nombre, mode: 'insensitive' };
+  }
+
+  if (tipoRutaBusId !== undefined) {
+    where.tipoRutaBusId = tipoRutaBusId;
   }
 
   if (resolucionId !== undefined) {

--- a/src/modules/tipos-ruta-bus/constants/tipo-ruta-bus-select.ts
+++ b/src/modules/tipos-ruta-bus/constants/tipo-ruta-bus-select.ts
@@ -1,0 +1,17 @@
+import { Prisma } from '@prisma/client';
+
+export const TIPO_RUTA_BUS_SELECT: Prisma.TipoRutaBusSelect = {
+  id: true,
+  tenantId: true,
+  nombre: true,
+};
+
+export const TIPO_RUTA_BUS_SELECT_WITH_RELATIONS: Prisma.TipoRutaBusSelect = {
+  ...TIPO_RUTA_BUS_SELECT,
+  tenant: {
+    select: {
+      id: true,
+      nombre: true,
+    },
+  },
+}; 

--- a/src/modules/tipos-ruta-bus/dto/create-tipo-ruta-bus.dto.ts
+++ b/src/modules/tipos-ruta-bus/dto/create-tipo-ruta-bus.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+
+export class CreateTipoRutaBusDto {
+  @ApiProperty({
+    description: 'Nombre del tipo de ruta de bus',
+    example: 'Interprovincial',
+  })
+  @IsString({ message: 'El nombre debe ser una cadena de caracteres' })
+  @IsNotEmpty({ message: 'El nombre es requerido' })
+  @MinLength(2, { message: 'El nombre debe tener al menos 2 caracteres' })
+  @MaxLength(50, { message: 'El nombre no puede exceder 50 caracteres' })
+  nombre: string;
+} 

--- a/src/modules/tipos-ruta-bus/dto/index.ts
+++ b/src/modules/tipos-ruta-bus/dto/index.ts
@@ -1,0 +1,2 @@
+export { CreateTipoRutaBusDto } from './create-tipo-ruta-bus.dto';
+export { UpdateTipoRutaBusDto } from './update-tipo-ruta-bus.dto'; 

--- a/src/modules/tipos-ruta-bus/dto/update-tipo-ruta-bus.dto.ts
+++ b/src/modules/tipos-ruta-bus/dto/update-tipo-ruta-bus.dto.ts
@@ -1,0 +1,5 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PartialType } from '@nestjs/swagger';
+import { CreateTipoRutaBusDto } from './create-tipo-ruta-bus.dto';
+
+export class UpdateTipoRutaBusDto extends PartialType(CreateTipoRutaBusDto) {} 

--- a/src/modules/tipos-ruta-bus/tipos-ruta-bus.controller.ts
+++ b/src/modules/tipos-ruta-bus/tipos-ruta-bus.controller.ts
@@ -1,0 +1,138 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  ParseIntPipe,
+  HttpStatus,
+  HttpCode,
+} from '@nestjs/common';
+import { TiposRutaBusService } from './tipos-ruta-bus.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { TipoUsuario, RolUsuario } from '@prisma/client';
+import { TenantActual } from '../../common/decorators/tenant-actual.decorator';
+import { CreateTipoRutaBusDto, UpdateTipoRutaBusDto } from './dto';
+import { ApiBearerAuth, ApiTags, ApiOperation } from '@nestjs/swagger';
+import { createApiOperation, CommonDescriptions } from '../../common/utils/swagger-descriptions.util';
+
+@ApiTags('tipos-ruta-bus')
+@ApiBearerAuth()
+@Controller('tipos-ruta-bus')
+export class TiposRutaBusController {
+  constructor(private readonly tiposRutaBusService: TiposRutaBusService) {}
+
+  @ApiOperation(
+    CommonDescriptions.getAll('tipos de ruta de bus', [
+      TipoUsuario.ADMIN_SISTEMA,
+      RolUsuario.ADMIN_COOPERATIVA,
+      RolUsuario.OFICINISTA,
+    ], 'Lista todos los tipos de ruta de bus de la cooperativa actual.')
+  )
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(
+    TipoUsuario.ADMIN_SISTEMA,
+    RolUsuario.ADMIN_COOPERATIVA,
+    RolUsuario.OFICINISTA,
+  )
+  @Get()
+  async obtenerTiposRutaBus(@TenantActual() tenantActual) {
+    const tiposRutaBus = await this.tiposRutaBusService.obtenerTiposRutaBus({
+      tenantId: tenantActual.id,
+    });
+    return tiposRutaBus;
+  }
+
+  @ApiOperation(
+    CommonDescriptions.getById('tipo de ruta de bus', [
+      TipoUsuario.ADMIN_SISTEMA,
+      RolUsuario.ADMIN_COOPERATIVA,
+      RolUsuario.OFICINISTA,
+    ], 'Obtiene los detalles de un tipo de ruta de bus específico.')
+  )
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(
+    TipoUsuario.ADMIN_SISTEMA,
+    RolUsuario.ADMIN_COOPERATIVA,
+    RolUsuario.OFICINISTA,
+  )
+  @Get(':id')
+  async obtenerTipoRutaBusPorId(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const tipoRutaBus = await this.tiposRutaBusService.obtenerTipoRutaBus({
+      id,
+      tenantId: tenantActual.id,
+    });
+    return tipoRutaBus;
+  }
+
+  @ApiOperation(
+    CommonDescriptions.create('tipo de ruta de bus', [
+      TipoUsuario.ADMIN_SISTEMA,
+      RolUsuario.ADMIN_COOPERATIVA,
+    ], 'Crea un nuevo tipo de ruta de bus para la cooperativa.')
+  )
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async crearTipoRutaBus(
+    @Body() createTipoRutaBusDto: CreateTipoRutaBusDto,
+    @TenantActual() tenantActual,
+  ) {
+    const tipoRutaBus = await this.tiposRutaBusService.crearTipoRutaBus(
+      tenantActual.id,
+      createTipoRutaBusDto,
+    );
+    return tipoRutaBus;
+  }
+
+  @ApiOperation(
+    CommonDescriptions.update('tipo de ruta de bus', [
+      TipoUsuario.ADMIN_SISTEMA,
+      RolUsuario.ADMIN_COOPERATIVA,
+    ], 'Actualiza la información de un tipo de ruta de bus existente.')
+  )
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Put(':id')
+  async actualizarTipoRutaBus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateTipoRutaBusDto: UpdateTipoRutaBusDto,
+    @TenantActual() tenantActual,
+  ) {
+    const tipoRutaBus = await this.tiposRutaBusService.actualizarTipoRutaBus(
+      id,
+      tenantActual.id,
+      updateTipoRutaBusDto,
+    );
+    return tipoRutaBus;
+  }
+
+  @ApiOperation(
+    CommonDescriptions.delete('tipo de ruta de bus', [
+      TipoUsuario.ADMIN_SISTEMA,
+      RolUsuario.ADMIN_COOPERATIVA,
+    ], 'Elimina un tipo de ruta de bus. Solo se puede eliminar si no tiene buses o rutas asociadas.')
+  )
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(TipoUsuario.ADMIN_SISTEMA, RolUsuario.ADMIN_COOPERATIVA)
+  @Delete(':id')
+  async eliminarTipoRutaBus(
+    @Param('id', ParseIntPipe) id: number,
+    @TenantActual() tenantActual,
+  ) {
+    const tipoRutaBus = await this.tiposRutaBusService.eliminarTipoRutaBus(
+      id,
+      tenantActual.id,
+    );
+    return tipoRutaBus;
+  }
+} 

--- a/src/modules/tipos-ruta-bus/tipos-ruta-bus.module.ts
+++ b/src/modules/tipos-ruta-bus/tipos-ruta-bus.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { TiposRutaBusController } from './tipos-ruta-bus.controller';
+import { TiposRutaBusService } from './tipos-ruta-bus.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TiposRutaBusController],
+  providers: [TiposRutaBusService],
+  exports: [TiposRutaBusService],
+})
+export class TiposRutaBusModule {} 

--- a/src/modules/tipos-ruta-bus/tipos-ruta-bus.service.ts
+++ b/src/modules/tipos-ruta-bus/tipos-ruta-bus.service.ts
@@ -1,0 +1,144 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+import { CreateTipoRutaBusDto, UpdateTipoRutaBusDto } from './dto';
+import { TIPO_RUTA_BUS_SELECT_WITH_RELATIONS } from './constants/tipo-ruta-bus-select';
+
+@Injectable()
+export class TiposRutaBusService {
+  constructor(private prisma: PrismaService) {}
+
+  async obtenerTiposRutaBus(
+    filtro: Prisma.TipoRutaBusWhereInput,
+    args: Prisma.TipoRutaBusSelect = TIPO_RUTA_BUS_SELECT_WITH_RELATIONS,
+  ) {
+    return await this.prisma.tipoRutaBus.findMany({
+      where: filtro,
+      orderBy: { nombre: 'asc' },
+      select: args,
+    });
+  }
+
+  async obtenerTipoRutaBus(
+    filtro: Prisma.TipoRutaBusWhereUniqueInput,
+    args: Prisma.TipoRutaBusSelect = TIPO_RUTA_BUS_SELECT_WITH_RELATIONS,
+  ) {
+    const tipoRutaBus = await this.prisma.tipoRutaBus.findUnique({
+      where: filtro,
+      select: args,
+    });
+
+    if (!tipoRutaBus) {
+      throw new NotFoundException(
+        `Tipo de ruta de bus con el filtro ${JSON.stringify(filtro)} no encontrado`,
+      );
+    }
+
+    return tipoRutaBus;
+  }
+
+  async crearTipoRutaBus(
+    tenantId: number,
+    datos: CreateTipoRutaBusDto,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const existente = await this.prisma.tipoRutaBus.findFirst({
+      where: {
+        tenantId,
+        nombre: datos.nombre,
+      },
+    });
+
+    if (existente) {
+      throw new ConflictException(
+        `Ya existe un tipo de ruta de bus con el nombre ${datos.nombre} en este tenant`,
+      );
+    }
+
+    return await (tx || this.prisma).tipoRutaBus.create({
+      data: {
+        tenantId,
+        nombre: datos.nombre,
+      },
+      select: TIPO_RUTA_BUS_SELECT_WITH_RELATIONS,
+    });
+  }
+
+  async actualizarTipoRutaBus(
+    id: number,
+    tenantId: number,
+    datos: UpdateTipoRutaBusDto,
+    tx?: Prisma.TransactionClient,
+  ) {
+    await this.obtenerTipoRutaBus({ id });
+
+    if (datos.nombre) {
+      const existente = await this.prisma.tipoRutaBus.findFirst({
+        where: {
+          tenantId,
+          nombre: datos.nombre,
+          NOT: {
+            id,
+          },
+        },
+      });
+
+      if (existente) {
+        throw new ConflictException(
+          `Ya existe un tipo de ruta de bus con el nombre ${datos.nombre} en este tenant`,
+        );
+      }
+    }
+
+    return await (tx || this.prisma).tipoRutaBus.update({
+      where: { id },
+      data: datos,
+      select: TIPO_RUTA_BUS_SELECT_WITH_RELATIONS,
+    });
+  }
+
+  async eliminarTipoRutaBus(
+    id: number,
+    tenantId: number,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const tipoRutaBus = await this.obtenerTipoRutaBus({ id });
+
+    if (tipoRutaBus.tenantId !== tenantId) {
+      throw new NotFoundException(
+        `El tipo de ruta de bus con ID ${id} no pertenece al tenant ${tenantId}`,
+      );
+    }
+
+    // Verificar si hay buses asociados
+    const busesAsociados = await this.prisma.bus.count({
+      where: { tipoRutaBusId: id },
+    });
+
+    if (busesAsociados > 0) {
+      throw new ConflictException(
+        `No se puede eliminar el tipo de ruta de bus porque tiene ${busesAsociados} bus(es) asociado(s)`,
+      );
+    }
+
+    // Verificar si hay rutas asociadas
+    const rutasAsociadas = await this.prisma.ruta.count({
+      where: { tipoRutaBusId: id },
+    });
+
+    if (rutasAsociadas > 0) {
+      throw new ConflictException(
+        `No se puede eliminar el tipo de ruta de bus porque tiene ${rutasAsociadas} ruta(s) asociada(s)`,
+      );
+    }
+
+    return await (tx || this.prisma).tipoRutaBus.delete({
+      where: { id },
+      select: TIPO_RUTA_BUS_SELECT_WITH_RELATIONS,
+    });
+  }
+} 

--- a/src/modules/viajes/constants/viaje-select.ts
+++ b/src/modules/viajes/constants/viaje-select.ts
@@ -25,6 +25,12 @@ export const VIAJE_SELECT_WITH_RELATIONS: Prisma.ViajeSelect = {
           id: true,
           nombre: true,
           descripcion: true,
+          tipoRutaBus: {
+            select: {
+              id: true,
+              nombre: true,
+            },
+          },
         },
       },
     },
@@ -35,6 +41,12 @@ export const VIAJE_SELECT_WITH_RELATIONS: Prisma.ViajeSelect = {
       numero: true,
       placa: true,
       totalAsientos: true,
+      tipoRutaBus: {
+        select: {
+          id: true,
+          nombre: true,
+        },
+      },
     },
   },
 };
@@ -50,6 +62,12 @@ export const VIAJE_SELECT_WITH_RELATIONS_WITH_PARADAS: Prisma.ViajeSelect = {
           id: true,
           nombre: true,
           descripcion: true,
+          tipoRutaBus: {
+            select: {
+              id: true,
+              nombre: true,
+            },
+          },
           paradas: {
             select: {
               id: true,
@@ -75,6 +93,12 @@ export const VIAJE_SELECT_WITH_RELATIONS_WITH_PARADAS: Prisma.ViajeSelect = {
       numero: true,
       placa: true,
       totalAsientos: true,
+      tipoRutaBus: {
+        select: {
+          id: true,
+          nombre: true,
+        },
+      },
     },
   },
 };

--- a/src/modules/viajes/dto/viaje-generado.dto.ts
+++ b/src/modules/viajes/dto/viaje-generado.dto.ts
@@ -19,6 +19,10 @@ export class ViajeGeneradoDto {
       id: number;
       nombre: string;
       descripcion?: string;
+      tipoRutaBus: {
+        id: number;
+        nombre: string;
+      };
     };
   };
 
@@ -30,6 +34,10 @@ export class ViajeGeneradoDto {
     numero: number;
     placa: string;
     totalAsientos: number;
+    tipoRutaBus: {
+      id: number;
+      nombre: string;
+    };
   };
 
   @ApiProperty({

--- a/src/modules/viajes/services/viajes-publico.service.ts
+++ b/src/modules/viajes/services/viajes-publico.service.ts
@@ -43,6 +43,12 @@ export class ViajesPublicoService {
           },
           orderBy: { orden: 'asc' },
         },
+        tipoRutaBus: {
+          select: {
+            id: true,
+            nombre: true,
+          },
+        },
       },
     });
 
@@ -105,10 +111,14 @@ export class ViajesPublicoService {
           ...viaje,
           precio: precioSegmento,
           tiempoViaje: tiempoSegmento,
+          tipoRuta: viaje.horarioRuta.ruta.tipoRutaBus,
         };
       }
 
-      return viaje;
+      return {
+        ...viaje,
+        tipoRuta: viaje.horarioRuta.ruta.tipoRutaBus,
+      };
     });
   }
 


### PR DESCRIPTION
This pull request introduces a new entity, `TipoRutaBus`, to the database schema and integrates it into the bus and route models. It also updates the seeding logic to include `TipoRutaBus` data and modifies the schema to reflect the changes. The most important changes involve schema updates, database migrations, and adjustments to the seeding logic.

### Schema Updates
* Added a new model `TipoRutaBus` to represent types of bus routes, with relationships to `Tenant`, `Bus`, and `Ruta`. (`prisma/schema.prisma`, [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR218-R234) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR247) [[3]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR331-R339)
* Updated `Bus` and `Ruta` models to include a foreign key relationship with `TipoRutaBus`. (`prisma/schema.prisma`, [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR247) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR331-R339)

### Database Migrations
* Created a new table `tipos_ruta_bus` to store `TipoRutaBus` data, replacing the previously created and dropped `tipos_ruta_buse` table. (`prisma/migrations/20250629014608_add_tipo_ruta_bus/migration.sql`, [[1]](diffhunk://#diff-85de9de49a91d24b5d8dd7b8c4e6dd70647c7a7d7aa055ba8c8aa014fd0a9d1bR1-R33); `prisma/migrations/20250629021519_add_tipo_ruta_bus/migration.sql`, [[2]](diffhunk://#diff-fc7707b5e2a430ce9c4bdb992e853b2eefe2183d587a3bd9ae5a173bf9ba2645R1-R38)
* Added foreign key constraints to link `tipos_ruta_bus` with `tenants`, `buses`, and `rutas`. (`prisma/migrations/20250629021519_add_tipo_ruta_bus/migration.sql`, [prisma/migrations/20250629021519_add_tipo_ruta_bus/migration.sqlR1-R38](diffhunk://#diff-fc7707b5e2a430ce9c4bdb992e853b2eefe2183d587a3bd9ae5a173bf9ba2645R1-R38))

### Seeding Logic Updates
* Updated `seed.ts` to include seeding logic for `TipoRutaBus` and pass it to the `seedBuses` and `seedRutas` functions. (`prisma/seed.ts`, [[1]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR9) [[2]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR27-R34) [[3]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR57)
* Modified `seed-buses.ts` to assign `TipoRutaBus` to buses during seeding. (`prisma/seeds/seed-buses.ts`, [[1]](diffhunk://#diff-bce90eb476c11b29ece79a3fa3ea7160e316c7ad0d6196aad2a3a0326c2ba13dL4-R24) [[2]](diffhunk://#diff-bce90eb476c11b29ece79a3fa3ea7160e316c7ad0d6196aad2a3a0326c2ba13dR41)
* Updated `seed-ruta-horario.ts` to include `TipoRutaBus` information for routes. (`prisma/seeds/seed-ruta-horario.ts`, [[1]](diffhunk://#diff-302ca357c5e9f2a57c4d3bf053d7cf141952665e22d20a96342c2ac58883eef9L5-R5) [[2]](diffhunk://#diff-302ca357c5e9f2a57c4d3bf053d7cf141952665e22d20a96342c2ac58883eef9R51) [[3]](diffhunk://#diff-302ca357c5e9f2a57c4d3bf053d7cf141952665e22d20a96342c2ac58883eef9R123) [[4]](diffhunk://#diff-302ca357c5e9f2a57c4d3bf053d7cf141952665e22d20a96342c2ac58883eef9R254)